### PR TITLE
Debug opt

### DIFF
--- a/demo/vshell.c
+++ b/demo/vshell.c
@@ -24,6 +24,7 @@ This library is based on ROTE written by Bruno Takahashi C. de Oliveira
 #include <stdio.h>
 #include <signal.h>
 #include <locale.h>
+#include <string.h>
 
 #include <vterm.h>
 

--- a/demo/vshell.c
+++ b/demo/vshell.c
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
     wrefresh(term_win);
 
     // create the terminal and have it run bash
-    vterm = vterm_create(80,25,VTERM_FLAG_RXVT);
+    vterm = vterm_create(80,25, VTERM_FLAG_RXVT | flags);
     vterm_set_colors(vterm,COLOR_WHITE,COLOR_BLACK);
     vterm_wnd_set(vterm,term_win);
 

--- a/demo/vshell.c
+++ b/demo/vshell.c
@@ -26,7 +26,7 @@ This library is based on ROTE written by Bruno Takahashi C. de Oliveira
 #include <locale.h>
 #include <string.h>
 
-#include <vterm.h>
+#include <../vterm.h>
 
 int screen_w, screen_h;
 WINDOW *term_win;
@@ -54,15 +54,15 @@ int main(int argc, char **argv)
     keypad(stdscr, TRUE);
     getmaxyx(stdscr, screen_h, screen_w);
 
-    if (argc > 2)
+    if (argc > 1)
     {
         // interate through argv[] looking for params
         for (i = 1; i < argc; i++)
         {
 
-            if (strncmp(argv[i], "--dump", 6)
+            if (strncmp(argv[i], "--dump", 6) == 0)
             {
-                flags |= VTERM_FLAGS_DUMP;
+                flags |= VTERM_FLAG_DUMP;
                 continue;
             }
         }

--- a/demo/vshell.c
+++ b/demo/vshell.c
@@ -30,12 +30,13 @@ This library is based on ROTE written by Bruno Takahashi C. de Oliveira
 int screen_w, screen_h;
 WINDOW *term_win;
 
-int main()
+int main(int argc, char **argv)
 {
     vterm_t     *vterm;
     int 		i, j, ch;
 	char		*locale;
     ssize_t     bytes;
+    int         flags = 0;
 
 	locale = setlocale(LC_ALL,"");
 
@@ -51,6 +52,21 @@ int main()
 
     keypad(stdscr, TRUE);
     getmaxyx(stdscr, screen_h, screen_w);
+
+    if (argc > 2)
+    {
+        // interate through argv[] looking for params
+        for (i = 1; i < argc; i++)
+        {
+
+            if (strncmp(argv[i], "--dump", 6)
+            {
+                flags |= VTERM_FLAGS_DUMP;
+                continue;
+            }
+        }
+    }
+
 
     /*
         initialize the color pairs the way rote_vt_draw expects it. You might

--- a/vterm.c
+++ b/vterm.c
@@ -30,8 +30,10 @@ This library is based on ROTE written by Bruno Takahashi C. de Oliveira
 #include <signal.h>
 #include <limits.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #include <sys/types.h>
+#include <sys/stat.h>
 
 #include "vterm.h"
 #include "vterm_private.h"
@@ -166,11 +168,11 @@ vterm_create(uint16_t width,uint16_t height,unsigned int flags)
 
         vterm->child_pid = child_pid;
 
-        if(flag & VTERM_FLAG_DUMP)
+        if(flags & VTERM_FLAG_DUMP)
         {
             sprintf(pos, "vterm-%d.dump", child_pid);
             vterm->debug_fd = open(vterm->debug_filepath,
-                O_CREAT | O_TRUNC | O_WRONLY);
+                O_CREAT | O_TRUNC | O_WRONLY, S_IWUSR | S_IRUSR);
         }
 
         if(ttyname_r(master_fd,vterm->ttyname,sizeof(vterm->ttyname) - 1) != 0)

--- a/vterm.c
+++ b/vterm.c
@@ -94,6 +94,14 @@ vterm_create(uint16_t width,uint16_t height,unsigned int flags)
 #endif
     }
 
+    if(flags & VTERM_FLAG_DUMP)
+    {
+        vterm->debug_filepath = (char*)calloc(PATH_MAX + 1,sizeof(char));
+        getcwd(vterm->debug_filepath, PATH_MAX);
+
+        // TODO:  write full path string
+    }
+
     // initial scrolling area is the whole window
     vterm->scroll_min = 0;
     vterm->scroll_max = height - 1;

--- a/vterm.c
+++ b/vterm.c
@@ -29,6 +29,7 @@ This library is based on ROTE written by Bruno Takahashi C. de Oliveira
 #include <termios.h>
 #include <signal.h>
 #include <limits.h>
+#include <unistd.h>
 
 #include <sys/types.h>
 
@@ -42,10 +43,12 @@ vterm_create(uint16_t width,uint16_t height,unsigned int flags)
     vterm_t         *vterm;
     struct passwd   *user_profile;
     char            *user_shell = NULL;
-    pid_t           child_pid;
+    pid_t           master_pid = 0;
+    pid_t           child_pid = 0;
     int             master_fd;
     struct winsize  ws = {.ws_xpixel = 0,.ws_ypixel = 0};
     int             i;
+    char            *pos = NULL;
 
 #ifdef NOCURSES
     flags = flags | VTERM_FLAG_NOCURSES;
@@ -96,10 +99,17 @@ vterm_create(uint16_t width,uint16_t height,unsigned int flags)
 
     if(flags & VTERM_FLAG_DUMP)
     {
+        // setup the base filepath for the dump file
         vterm->debug_filepath = (char*)calloc(PATH_MAX + 1,sizeof(char));
         getcwd(vterm->debug_filepath, PATH_MAX);
 
-        // TODO:  write full path string
+        pos = vterm->debug_filepath;
+        pos += strlen(vterm->debug_filepath);
+        if (pos[0] != '/')
+        {
+            pos[0] = '/';
+            pos++;
+        }
     }
 
     // initial scrolling area is the whole window
@@ -119,43 +129,50 @@ vterm_create(uint16_t width,uint16_t height,unsigned int flags)
     {
         child_pid = forkpty(&master_fd,NULL,NULL,&ws);
         vterm->pty_fd = master_fd;
-    
+
         if(child_pid < 0)
         {
             vterm_destroy(vterm);
             return NULL;
         }
-    
+
         if(child_pid == 0)
         {
             signal(SIGINT,SIG_DFL);
-    
+
             // default is rxvt emulation
             setenv("TERM","rxvt",1);
-    
+
             if(flags & VTERM_FLAG_VT100)
             {
                 setenv("TERM","vt100",1);
             }
-    
+
             user_profile = getpwuid(getuid());
             if(user_profile == NULL) user_shell = "/bin/sh";
             else if(user_profile->pw_shell == NULL) user_shell = "/bin/sh";
             else user_shell = user_profile->pw_shell;
-    
+
             if(user_shell == NULL) user_shell="/bin/sh";
-    
+
             // start the shell
             if(execl(user_shell,user_shell,"-l",NULL) == -1)
             {
                 exit(EXIT_FAILURE);
             }
-    
+
             exit(EXIT_SUCCESS);
         }
-    
+
         vterm->child_pid = child_pid;
-    
+
+        if(flag & VTERM_FLAG_DUMP)
+        {
+            sprintf(pos, "vterm-%d.dump", child_pid);
+            vterm->debug_fd = open(vterm->debug_filepath,
+                O_CREAT | O_TRUNC | O_WRONLY);
+        }
+
         if(ttyname_r(master_fd,vterm->ttyname,sizeof(vterm->ttyname) - 1) != 0)
         {
             snprintf(vterm->ttyname,sizeof(vterm->ttyname) - 1,"vterm");

--- a/vterm.h
+++ b/vterm.h
@@ -84,9 +84,11 @@ This library is based on ROTE written by Bruno Takahashi C. de Oliveira
 #define LIBVTERM_VERSION       "0.99.10"
 
 #define VTERM_FLAG_RXVT        0                       // default
-#define VTERM_FLAG_VT100       (1<<1)
-#define VTERM_FLAG_NOPTY       (1<<2)  // skip all the fd and pty stuff - just render input args bytestream to a buffer
-#define VTERM_FLAG_NOCURSES    (1<<3)  // skip the curses WINDOW stuff - return the char cell array if required
+#define VTERM_FLAG_VT100       (1 << 1)
+#define VTERM_FLAG_NOPTY       (1 << 2)  // skip all the fd and pty stuff - just render input args bytestream to a buffer
+#define VTERM_FLAG_NOCURSES    (1 << 3)  // skip the curses WINDOW stuff - return the char cell array if required
+
+#define VTERM_FLAG_DUMP        (1 << 8)  // tell libvterm to write stream data to a dump file for debugging
 
 // Need this to be public if we want to expose the buffer to callers.
 struct _vterm_cell_s

--- a/vterm_private.h
+++ b/vterm_private.h
@@ -90,7 +90,7 @@ struct _vterm_s
     unsigned int    flags;                  // user options
     unsigned int    state;                  // internal state control
 
-    char            *debug_filepaht;
+    char            *debug_filepath;
     int             debug_fd;
 
     void            (*write)        (vterm_t*,uint32_t);

--- a/vterm_private.h
+++ b/vterm_private.h
@@ -87,8 +87,11 @@ struct _vterm_s
                                             */
 
     pid_t           child_pid;              // pid of the child process
-    unsigned int    flags;                              // user options
+    unsigned int    flags;                  // user options
     unsigned int    state;                  // internal state control
+
+    char            *debug_filepaht;
+    int             debug_fd;
 
     void            (*write)        (vterm_t*,uint32_t);
     int             (*esc_handler)  (vterm_t*);

--- a/vterm_read.c
+++ b/vterm_read.c
@@ -121,15 +121,11 @@ vterm_read_pipe(vterm_t *vterm)
     // render the data to the offscreen terminal buffer.
     if((bytes_waiting > 0) && (bytes_read != -1))
     {
-
-#ifdef _DEBUG
-        snprintf(debug_file,(sizeof(debug_file) - 1),
-            "/tmp/libvterm-%d-log",vterm->child_pid);
-
-        f_debug = fopen(debug_file,"a");
-        fwrite(buf,sizeof(char),bytes_read,f_debug);
-        fclose(f_debug);
-#endif
+        // write debug information if enabled
+        if(vterm->flags & VTERM_FLAG_DUMP)
+        {
+            write(vterm->debug_fd, (const void*)buf, bytes);
+        }
 
         vterm_render(vterm,buf,bytes_read);
     }
@@ -141,5 +137,3 @@ vterm_read_pipe(vterm_t *vterm)
 
     return bytes_waiting - bytes_remaining;
 }
-
-

--- a/vterm_read.c
+++ b/vterm_read.c
@@ -46,6 +46,7 @@ vterm_read_pipe(vterm_t *vterm)
     int             bytes_peek = 0;
 	size_t			bytes_waiting;
     ssize_t			bytes_read = 0;
+    ssize_t         bytes_written = 0;
     size_t          bytes_remaining = 0;
     size_t          bytes_total = 0;
     int             retval;
@@ -124,7 +125,8 @@ vterm_read_pipe(vterm_t *vterm)
         // write debug information if enabled
         if(vterm->flags & VTERM_FLAG_DUMP)
         {
-            write(vterm->debug_fd, (const void*)buf, bytes_read);
+            bytes_written = write(vterm->debug_fd,
+                (const void *)buf, bytes_read);
         }
 
         vterm_render(vterm,buf,bytes_read);

--- a/vterm_read.c
+++ b/vterm_read.c
@@ -124,7 +124,7 @@ vterm_read_pipe(vterm_t *vterm)
         // write debug information if enabled
         if(vterm->flags & VTERM_FLAG_DUMP)
         {
-            write(vterm->debug_fd, (const void*)buf, bytes);
+            write(vterm->debug_fd, (const void*)buf, bytes_read);
         }
 
         vterm_render(vterm,buf,bytes_read);


### PR DESCRIPTION
Added a --dump param to vshell and libvterm internals so that debugging missing escape codes would be easier.