### PR TITLE
fix SGR reset. make midnight commander work in stick mode

### DIFF
--- a/vterm_csi_CUx.c
+++ b/vterm_csi_CUx.c
@@ -35,12 +35,12 @@ void interpret_csi_CUx(vterm_t *vterm,char verb,int param[],int pcount)
 
    switch (verb)
    {
-      case 'A':         vterm->crow -= n;          break;
+      case 'A':         vterm->crow -= n;               break;
       case 'B':
-      case 'e':         vterm->crow += n;          break;
+      case 'e':         vterm->crow += n;               break;
       case 'C':
-      case 'a':         vterm->ccol += n;          break;
-      case 'D':         vterm->ccol -= n;          break;
+      case 'a':         vterm->ccol += n;               break;
+      case 'D':         vterm->ccol -= n;               break;
       case 'E':
       {
          vterm->crow += n;
@@ -63,3 +63,17 @@ void interpret_csi_CUx(vterm_t *vterm,char verb,int param[],int pcount)
 
    return;
 }
+
+/*
+// DEBUG code
+void _write_row_forward(vterm_t *vterm, int len)
+{
+    int i = 0;
+
+    for(i = 0; i < len; i++)
+    {
+        vterm->cells[vterm->crow][i].ch = 'b';
+        vterm->cells[vterm->crow][i].attr = vterm->curattr;
+    }
+}
+*/

--- a/vterm_csi_DECSTBM.c
+++ b/vterm_csi_DECSTBM.c
@@ -65,4 +65,3 @@ void interpret_csi_DECSTBM(vterm_t *vterm,int param[],int pcount)
 
    return;
 }
-

--- a/vterm_csi_SGR.c
+++ b/vterm_csi_SGR.c
@@ -157,6 +157,7 @@ void interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
              if( GetFGBGFromColorIndex( vterm->colors, &fg, &bg )==0 )
              {
                  vterm->fg = fg;
+                 // vterm->fg = COLOR_RED;
                  colors = FindColorPair( vterm->fg, vterm->bg );
              }
              else
@@ -173,18 +174,20 @@ void interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
 #else
              short default_fg,default_bg;
              pair_content(vterm->colors,&default_fg,&default_bg);
-             vterm->fg=default_fg;
+             vterm->fg = default_fg;
+             // vterm->fg = COLOR_RED;
              colors=find_color_pair(vterm, vterm->fg,vterm->bg);
 #endif
          }
          if(colors==-1) colors=0;
+         vterm->curattr = 0;
          vterm->curattr |= COLOR_PAIR(colors);
          continue;
       }
 
       if(param[i]==49)                                // reset bg color
       {
-         if( vterm->flags & VTERM_FLAG_NOCURSES ) // no ncurses
+         if(vterm->flags & VTERM_FLAG_NOCURSES) // no ncurses
          {
              int fg, bg;
              if( GetFGBGFromColorIndex( vterm->colors, &fg, &bg )==0 )
@@ -206,14 +209,15 @@ void interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
 #else
              short default_fg,default_bg;
              pair_content(vterm->colors,&default_fg,&default_bg);
-             vterm->bg=default_bg;
+             vterm->bg = default_bg;
              colors=find_color_pair(vterm, vterm->fg,vterm->bg);
+             // colors=find_color_pair(vterm, vterm->bg,vterm->fg);
 #endif
          }
          if(colors==-1) colors=0;
+         vterm->curattr = 0;
          vterm->curattr |= COLOR_PAIR(colors);
          continue;
       }
    }
 }
-


### PR DESCRIPTION
Clear attributes on SGR reset for FB and BG.  This make Midnight Commander work in "stick char mode".