### PR TITLE
Utf8 parse

### DIFF
--- a/vterm.c
+++ b/vterm.c
@@ -143,8 +143,8 @@ vterm_create(uint16_t width,uint16_t height,unsigned int flags)
             signal(SIGINT,SIG_DFL);
 
             // default is rxvt emulation
-            setenv("TERM","rxvt",1);
-
+            setenv("TERM", "rxvt", 1);
+            
             if(flags & VTERM_FLAG_VT100)
             {
                 setenv("TERM","vt100",1);

--- a/vterm_csi_SGR.c
+++ b/vterm_csi_SGR.c
@@ -66,7 +66,8 @@ void interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
    {
       if(param[i]==0)                                 // reset attributes
       {
-         vterm->curattr=A_NORMAL;
+         vterm->curattr = A_NORMAL;
+         // vterm->curattr = 0;
          continue;
       }
 

--- a/vterm_private.h
+++ b/vterm_private.h
@@ -31,10 +31,12 @@ This library is based on ROTE written by Bruno Takahashi C. de Oliveira
 #  include <curses.h>
 #endif
 
-#define ESEQ_BUF_SIZE           128          // size of escape sequence buffer
+#define ESEQ_BUF_SIZE           128         // size of escape sequence buffer
+#define UTF8_BUF_SIZE           5           // 4 bytes + 0-terminator
 
 #define STATE_ALT_CHARSET       (1 << 1)
 #define STATE_ESCAPE_MODE       (1 << 2)
+#define STATE_UTF8_MODE         (1 << 3)
 
 #define STATE_PIPE_ERR          (1 << 8)
 #define STATE_CHILD_EXITED      (1 << 9)
@@ -43,52 +45,63 @@ This library is based on ROTE written by Bruno Takahashi C. de Oliveira
 
 #define IS_MODE_ESCAPED(x)      (x->state & STATE_ESCAPE_MODE)
 #define IS_MODE_ACS(x)          (x->state & STATE_ALT_CHARSET)
+#define IS_MODE_UTF8(x)         (x->state & STATE_UTF8_MODE)
 
 struct _vterm_s
 {
-    int                rows,cols;              // terminal height & width
+    int             rows,cols;                  // terminal height & width
 #ifndef NOCURSES
-    WINDOW          *window;                // curses window
+    WINDOW          *window;                    // curses window
 #endif
     vterm_cell_t    **cells;
-    char            ttyname[96];            // populated with ttyname_r()
-    char            prgname[128];           /*
-                                               this can be the name of the
-                                               application running in the
-                                               terminal.  the data is supplied
-                                               by the Xterm OSC code sequences
-                                               but is currently not supported
-                                               by libvterm.
-                                            */
-    int             curattr;                // current attribute set
-    int             crow,ccol;                // current cursor column & row
-    int             scroll_min;                // top of scrolling region
-    int             scroll_max;                // bottom of scrolling region
-    int             saved_x,saved_y;        // saved cursor coords
-    short           colors;                 // color pair for default fg/bg
-    int             fg,bg;                  // current fg/bg colors
+    char            ttyname[96];                // populated with ttyname_r()
 
-    char            esbuf[ESEQ_BUF_SIZE];   /*
-                                               0-terminated string. Does
-                                               NOT include the initial
-                                               escape (\x1B) character.
-                                            */
+    char            prgname[128];               /*
+                                                    this can be the name of the
+                                                    application running in the
+                                                    terminal.  the data is
+                                                    supplied by the Xterm OSC
+                                                    code sequences but is
+                                                    currently not supported
+                                                    by libvterm.
+                                                */
 
-    int             esbuf_len;                /*
-                                               length of buffer. The
-                                               following property is
-                                               always kept:
-                                               esbuf[esbuf_len] == '\0'
-                                            */
+    int             curattr;                    // current attribute set
+    int             crow,ccol;                  // current cursor column & row
+    int             scroll_min;                 // top of scrolling region
+    int             scroll_max;                 // bottom of scrolling region
+    int             saved_x,saved_y;            // saved cursor coords
+    short           colors;                     // color pair for default fg/bg
+    int             fg,bg;                      // current fg/bg colors
 
-    int             pty_fd;                    /*
-                                               file descriptor for the pty
-                                               attached to this terminal.
-                                            */
+    char            esbuf[ESEQ_BUF_SIZE];       /*
+                                                    0-terminated string. Does
+                                                    NOT include the initial
+                                                    escape (\x1B) character.
+                                                */
 
-    pid_t           child_pid;              // pid of the child process
-    unsigned int    flags;                  // user options
-    unsigned int    state;                  // internal state control
+    int             esbuf_len;                  /*
+                                                    length of buffer. The
+                                                    following property is
+                                                    always kept:
+                                                    esbuf[esbuf_len] == '\0'
+                                                */
+
+    char            utf8_buf[UTF8_BUF_SIZE];    /*
+                                                    0-terminated string that
+                                                    is the UTF-8 coding.
+                                                */
+
+    int             utf8_buf_len;               //  number of utf8 bytes
+
+    int             pty_fd;                     /*
+                                                    file descriptor for the pty
+                                                    attached to this terminal.
+                                                */
+
+    pid_t           child_pid;                  // pid of the child process
+    unsigned int    flags;                      // user options
+    unsigned int    state;                      // internal state control
 
     char            *debug_filepath;
     int             debug_fd;
@@ -97,6 +110,6 @@ struct _vterm_s
     int             (*esc_handler)  (vterm_t*);
 };
 
-#define VTERM_CELL(vterm_ptr,x,y)           ((y * vterm_ptr->cols) + x)
+#define VTERM_CELL(vterm_ptr,x,y)               ((y * vterm_ptr->cols) + x)
 
 #endif

--- a/vterm_render.h
+++ b/vterm_render.h
@@ -29,11 +29,8 @@ This library is based on ROTE written by Bruno Takahashi C. de Oliveira
 
 #include "vterm.h"
 
-// made public - moved to vterm.h
-// void vterm_render(vterm_t *,const char *data,int len);
 void vterm_put_char(vterm_t *vterm,chtype c);
 void vterm_render_ctrl_char(vterm_t *vterm,char c);
 void try_interpret_escape_seq(vterm_t *vterm);
 
 #endif
-

--- a/vterm_utf8.c
+++ b/vterm_utf8.c
@@ -88,18 +88,26 @@ vterm_utf8_decode(vterm_t *vterm, chtype *utf8_char)
 
     switch (utf8_code)
     {
-        case 0x0000C2B7:    { *utf8_char = ACS_BULLET;          break;}
-
+        /*
+            these should map to ACS Teletype 5410v1 symbols but that
+            doesn't seem to work on many terminals so just render the
+            ascii doppelganger.
+        */
         case 0x00E28092:
         case 0x00E28093:    { *utf8_char = '-';                 break;}
-
-        case 0x00E28094:
-        case 0x00E28095:    { *utf8_char = ACS_HLINE;           break;}
 
         case 0x00E28690:    { *utf8_char = '<';                 break;}
         case 0x00E28691:    { *utf8_char = '^';                 break;}
         case 0x00E28692:    { *utf8_char = '>';                 break;}
         case 0x00E28693:    { *utf8_char = 'v';                 break;}
+
+        case 0x00E296AE:    { *utf8_char = '#';                 break;}
+
+#ifndef NOCURSES
+        case 0x0000C2B7:    { *utf8_char = ACS_BULLET;          break;}
+
+        case 0x00E28094:
+        case 0x00E28095:    { *utf8_char = ACS_HLINE;           break;}
 
         case 0x00E29480:
         case 0x00E29481:    { *utf8_char = ACS_HLINE;           break;}
@@ -120,8 +128,32 @@ vterm_utf8_decode(vterm_t *vterm, chtype *utf8_char)
         case 0x00E29691:
         case 0x00E29692:
         case 0x00E29693:    { *utf8_char = ACS_CKBOARD;         break;}
+#else
+        case 0x0000C2B7:    { *utf8_char = 'o';                 break;}
 
-        case 0x00E296AE:    { *utf8_char = '#';                 break;}
+        case 0x00E28094:
+        case 0x00E28095:    { *utf8_char = '-';                 break;}
+
+        case 0x00E29480:
+        case 0x00E29481:    { *utf8_char = '-';                 break;}
+
+        case 0x00E29482:
+        case 0x00E29483:    { *utf8_char = '|';                 break;}
+
+        case 0x00E2948C:    { *utf8_char = '+';                 break;}
+        case 0x00E29490:    { *utf8_char = '+';                 break;}
+        case 0x00E29494:    { *utf8_char = '+';                 break;}
+        case 0x00E29498:    { *utf8_char = '+';                 break;}
+
+        case 0x00E2949C:    { *utf8_char = '+';                 break;}
+        case 0x00E294A4:    { *utf8_char = '+';                 break;}
+        case 0x00E294AC:	{ *utf8_char = '+';                 break;}
+        case 0x00E294B4:    { *utf8_char = '+';                 break;}
+
+        case 0x00E29691:
+        case 0x00E29692:
+        case 0x00E29693:    { *utf8_char = '#';                 break;}
+#endif
 
         // render a harmless space when we don't know what to do
         default:            { *utf8_char = ' ';                 break;}

--- a/vterm_utf8.c
+++ b/vterm_utf8.c
@@ -1,0 +1,142 @@
+/*
+LICENSE INFORMATION:
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License (LGPL) as published by the Free Software Foundation.
+
+Please refer to the COPYING file for more information.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+
+Copyright (c) 2017 Bryan Christ
+*/
+
+#include <string.h>
+#include <inttypes.h>
+
+#include "vterm.h"
+#include "vterm_private.h"
+
+/*
+    the way UTF-8 is encoded, we can just test the highest bit, pop it
+    off, and count, in order to know how many bytes are in the code
+    sequence.
+*/
+#define UTF8_BIT_MASK       0x80        // binary 10000000
+
+void
+vterm_utf8_start(vterm_t *vterm)
+{
+    vterm->state |= STATE_UTF8_MODE;
+
+    // zero out the utf-8 buffer just in case
+    vterm->utf8_buf_len = 0;
+    vterm->utf8_buf[0] = '\0';
+
+    return;
+}
+
+void
+vterm_utf8_cancel(vterm_t *vterm)
+{
+    vterm->state &= ~STATE_UTF8_MODE;
+
+    // zero out the utf-8 buffer for the next run
+    vterm->utf8_buf_len = 0;
+    vterm->utf8_buf[0] = '\0';
+
+    return;
+}
+
+int
+vterm_utf8_decode(vterm_t *vterm, chtype *utf8_char)
+{
+    uint32_t            utf8_code = 0;
+    uint8_t             first_byte = 0;
+    int                 byte_count = 0;
+    int                 i = 0;
+
+    first_byte = (uint8_t)vterm->utf8_buf[0];
+
+    while (first_byte & UTF8_BIT_MASK)
+    {
+        byte_count++;
+        first_byte = first_byte << 1;
+    }
+
+    // too early to decode.  return back for more reading.
+    if (vterm->utf8_buf_len < byte_count) return -1;
+
+    // TODO:  this is a band-aid
+
+    for (i = 0; i < byte_count; i++)
+    {
+        utf8_code |= (uint8_t)vterm->utf8_buf[i];
+
+        // don't shift on last byte
+        if (i + 1 >= byte_count) break;
+
+        utf8_code = utf8_code << 8;
+    }
+
+    switch (utf8_code)
+    {
+        case 0x0000C2B7:    { *utf8_char = ACS_BULLET;          break;}
+
+        case 0x00E28092:
+        case 0x00E28093:    { *utf8_char = '-';                 break;}
+
+        case 0x00E28094:
+        case 0x00E28095:    { *utf8_char = ACS_HLINE;           break;}
+
+        case 0x00E28690:    { *utf8_char = '<';                 break;}
+        case 0x00E28691:    { *utf8_char = '^';                 break;}
+        case 0x00E28692:    { *utf8_char = '>';                 break;}
+        case 0x00E28693:    { *utf8_char = 'v';                 break;}
+
+        case 0x00E29480:
+        case 0x00E29481:    { *utf8_char = ACS_HLINE;           break;}
+
+        case 0x00E29482:
+        case 0x00E29483:    { *utf8_char = ACS_VLINE;           break;}
+
+        case 0x00E2948C:    { *utf8_char = ACS_ULCORNER;        break;}
+        case 0x00E29490:    { *utf8_char = ACS_URCORNER;        break;}
+        case 0x00E29494:    { *utf8_char = ACS_LLCORNER;        break;}
+        case 0x00E29498:    { *utf8_char = ACS_LRCORNER;        break;}
+
+        case 0x00E2949C:    { *utf8_char = ACS_LTEE;            break;}
+        case 0x00E294A4:    { *utf8_char = ACS_RTEE;            break;}
+        case 0x00E294AC:	{ *utf8_char = ACS_TTEE;            break;}
+        case 0x00E294B4:    { *utf8_char = ACS_BTEE;            break;}
+
+        case 0x00E29691:
+        case 0x00E29692:
+        case 0x00E29693:    { *utf8_char = ACS_CKBOARD;         break;}
+
+        case 0x00E296AE:    { *utf8_char = '#';                 break;}
+
+        // render a harmless space when we don't know what to do
+        default:            { *utf8_char = ' ';                 break;}
+    }
+
+/*
+    {
+        FILE *f;
+        f = fopen("value.dump", "a");
+        fprintf(f, "%02x %02x %02x %02x\n",
+            vterm->utf8_buf[0], vterm->utf8_buf[1],
+            vterm->utf8_buf[2], vterm->utf8_buf[3]);
+        fprintf(f, "utf-8 char: %08x\n", utf8_code);
+        fclose(f);
+    }
+*/
+    return byte_count;
+}

--- a/vterm_utf8.h
+++ b/vterm_utf8.h
@@ -1,0 +1,33 @@
+#ifndef _VTERM_UTF8_H_
+#define _VTERM_UTF8_H_
+
+/*
+LICENSE INFORMATION:
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License (LGPL) as published by the Free Software Foundation.
+
+Please refer to the COPYING file for more information.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+
+Copyright (c) 2004 Bruno T. C. de Oliveira
+*/
+
+#include <curses.h>
+
+#include "vterm.h"
+
+void    vterm_utf8_start(vterm_t *vterm);
+void    vterm_utf8_cancel(vterm_t *vterm);
+
+int     vterm_utf8_decode(vterm_t *vterm, chtype *utf8_char);
+
+#endif


### PR DESCRIPTION
Adds primitive support for utf-8 by mapping common utf-8 line-art codings to alt-char-set or ascii doppelgangers.