### PR TITLE
minor fixes

### DIFF
--- a/vterm_buffer.h
+++ b/vterm_buffer.h
@@ -46,6 +46,8 @@ int     vterm_buffer_clone(vterm_t *vterm, int src_idx, int dst_idx,
 #define VCELL_SET_COLORS(_cell, _desc) \
                 { \
                     _cell.colors = _desc->colors; \
+                    _cell.fg = _desc->fg; \
+                    _cell.bg = _desc->bg; \
                     _cell.f_rgb[0] = _desc->f_rgb[0]; \
                     _cell.f_rgb[1] = _desc->f_rgb[1]; \
                     _cell.f_rgb[2] = _desc->f_rgb[2]; \

--- a/vterm_csi.c
+++ b/vterm_csi.c
@@ -65,16 +65,12 @@ vterm_interpret_csi(vterm_t *vterm)
         a standardized escape sequence the [ and ? will only occur
         once so put them at the bottom.
     */
+    csiparam[param_count] = 0;
+    if(*p != verb) param_count = 1;
     for(;;)
     {
         if(isdigit(*p))
         {
-            if(param_count == 0)
-            {
-                csiparam[param_count] = 0;
-                param_count++;
-            }
-
             // increaase order of prev digit (10s column, 100s column, etc...)
             csiparam[param_count - 1] *= 10;
             csiparam[param_count - 1] += *p - '0';

--- a/vterm_csi_SGR.c
+++ b/vterm_csi_SGR.c
@@ -59,7 +59,7 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
                             [0]             = &&csi_sgr_RESET,
                             [1]             = &&csi_sgr_BOLD_ON,
                             [2]             = &&csi_sgr_DIM_ON,
-                            [3]             = &&csi_sgr_UNDERLINE_ON,
+                            [4]             = &&csi_sgr_UNDERLINE_ON,
                             [5]             = &&csi_sgr_BLINK_ON,
                             [7]             = &&csi_sgr_REVERSE_ON,
                             [8]             = &&csi_sgr_INVISIBLE_ON,
@@ -145,7 +145,7 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
             continue;
 
         csi_sgr_UNDERLINE_ON:
-            // code 3
+            // code 4
             v_desc->curattr |= A_UNDERLINE;
             continue;
 


### PR DESCRIPTION
While trying to embed your library into my workflow and testing it with certain terminal applications (partly ncurses-based) I noticed some minor bugs.
I also noticed that without start_colors() it crashed badly in color_cache_find_lru_pair() and read in the code that NONCURSES in the feature should get rid of such a dependency. I might also look into that, but for me it works with those fixes.