### PR TITLE
Refactor

### DIFF
--- a/vterm_csi_SGR.c
+++ b/vterm_csi_SGR.c
@@ -35,7 +35,7 @@
 #include "color_cache.h"
 
 void
-_vterm_set_color_pair_safe(vterm_t *vterm, short colors, int fg, int bg);
+_vterm_set_color_pair_safe(vterm_desc_t *v_desc, short colors, int fg, int bg);
 
 long
 interpret_custom_color(vterm_t *vterm, int param[], int pcount);
@@ -105,7 +105,7 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
             // reset attributes
             v_desc->curattr = A_NORMAL;
 
-            _vterm_set_color_pair_safe(vterm, v_desc->default_colors,
+            _vterm_set_color_pair_safe(v_desc, v_desc->default_colors,
                 v_desc->fg, v_desc->bg);
 
             // attribute reset is an implicit color reset too so we'll
@@ -200,7 +200,7 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
                     v_desc->fg, v_desc->bg);
             }
 
-            _vterm_set_color_pair_safe(vterm, colors,
+            _vterm_set_color_pair_safe(v_desc, colors,
                 v_desc->fg, v_desc->bg);
 
             continue;
@@ -225,7 +225,7 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
                         v_desc->fg, v_desc->bg);
                 }
 
-                _vterm_set_color_pair_safe(vterm, colors,
+                _vterm_set_color_pair_safe(v_desc, colors,
                     v_desc->fg, v_desc->bg);
             }
 
@@ -251,7 +251,7 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
             // one addtl safeguard
             if(colors == -1) colors = 0;
 
-            _vterm_set_color_pair_safe(vterm, colors, v_desc->fg, v_desc->bg);
+            _vterm_set_color_pair_safe(v_desc, colors, v_desc->fg, v_desc->bg);
 
             continue;
 
@@ -268,7 +268,7 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
                 colors = color_cache_add_pair(vterm, v_desc->fg, v_desc->bg);
             }
 
-            _vterm_set_color_pair_safe(vterm, colors, v_desc->fg, v_desc->bg);
+            _vterm_set_color_pair_safe(v_desc, colors, v_desc->fg, v_desc->bg);
 
             continue;
 
@@ -292,7 +292,7 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
                             v_desc->fg, v_desc->bg);
                 }
 
-                _vterm_set_color_pair_safe(vterm, colors,
+                _vterm_set_color_pair_safe(v_desc, colors,
                     v_desc->fg, v_desc->bg);
 
             }
@@ -320,7 +320,7 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
             // one addtl safeguard
             if(colors == -1) colors = 0;
 
-            _vterm_set_color_pair_safe(vterm, colors,
+            _vterm_set_color_pair_safe(v_desc, colors,
                 v_desc->fg, v_desc->bg);
 
             continue;
@@ -351,7 +351,7 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
                 colors = color_cache_add_pair(vterm, v_desc->fg, v_desc->bg);
             }
 
-            _vterm_set_color_pair_safe(vterm, colors, v_desc->fg, v_desc->bg);
+            _vterm_set_color_pair_safe(v_desc, colors, v_desc->fg, v_desc->bg);
 
             continue;
 
@@ -379,7 +379,7 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
                 colors = color_cache_add_pair(vterm, v_desc->fg, v_desc->bg);
             }
 
-            _vterm_set_color_pair_safe(vterm, colors,
+            _vterm_set_color_pair_safe(v_desc, colors,
                  v_desc->fg, v_desc->bg);
 
             continue;
@@ -390,15 +390,8 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
 }
 
 inline void
-_vterm_set_color_pair_safe(vterm_t *vterm, short colors, int fg, int bg)
+_vterm_set_color_pair_safe(vterm_desc_t *v_desc, short colors, int fg, int bg)
 {
-    vterm_desc_t    *v_desc = NULL;
-    int             idx;
-
-    // set vterm_desc buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
-
     v_desc->colors = colors;
 
     color_content(fg, &v_desc->f_rgb[0], &v_desc->f_rgb[1], &v_desc->f_rgb[2]);

--- a/vterm_csi_SGR.c
+++ b/vterm_csi_SGR.c
@@ -91,22 +91,8 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
     if(pcount == 0)
     {
         // reset attributes
-        v_desc->curattr = A_NORMAL;
-
-        _vterm_set_color_pair_safe(vterm, v_desc->default_colors,
-            v_desc->fg, v_desc->bg);
-
-        // attribute reset is an implicit color reset too so we'll
-        // do a nested call to handle it.
-        nested_params[0] = 39;
-        nested_params[1] = 49;
-
-        depth++;
-
-        interpret_csi_SGR(vterm, nested_params, 2);
-        depth--;
-
-        return;
+        pcount = 1;
+        param[0] = 0;
     }
 
     for(i = 0; i < pcount; i++)


### PR DESCRIPTION
Since SGR commands cannot change the active buffer, do not look it up all the time. Also refactoring the redundant code for "reset".