### PR TITLE
Make support for UTF-8 configurable

### DIFF
--- a/vterm.c
+++ b/vterm.c
@@ -77,6 +77,9 @@ vterm_init(vterm_t *vterm, uint16_t width, uint16_t height, uint32_t flags)
 #ifdef NOCURSES
     flags = flags | VTERM_FLAG_NOCURSES;
 #endif
+#ifdef NOUTF8
+    flags = flags | VTERM_FLAG_NOUTF8;
+#endif
 
     if(height <= 0 || width <= 0) return NULL;
 

--- a/vterm.h
+++ b/vterm.h
@@ -43,12 +43,16 @@
                                                     args byte stream to a
                                                     buffer.
                                                 */
-
 #define VTERM_FLAG_NOCURSES     (1UL << 9)      /*
                                                     skip the curses WINDOW
                                                     stuff.  return the char
                                                     cell array if required.
                                                 */
+#define VTERM_FLAG_NOUTF8       (1UL << 10)     /*  disable the detection
+                                                    and handling for UTF-8
+                                                    completely
+                                                */
+
 
 #define VTERM_FLAG_C8           (1UL << 14)     /*
                                                     never try to used extended

--- a/vterm_private.h
+++ b/vterm_private.h
@@ -158,11 +158,13 @@ struct _vterm_s
                                                     always kept:
                                                     esbuf[esbuf_len] == '\0'
                                                 */
+#ifndef NOUTF8
     int             utf8_buf_len;               //  number of utf8 bytes
     char            utf8_buf[UTF8_BUF_SIZE];    /*
                                                     0-terminated string that
                                                     is the UTF-8 coding.
                                                 */
+#endif
 
     ssize_t         reply_buf_sz;               //  size of reply
     char            reply_buf[32];              /*

--- a/vterm_render.c
+++ b/vterm_render.c
@@ -32,9 +32,11 @@ vterm_put_char(vterm_t *vterm, chtype c, wchar_t *wch);
 void
 vterm_render(vterm_t *vterm, char *data, int len)
 {
+#ifndef NOUTF8
     chtype          utf8_char;
     wchar_t         wch[CCHARW_MAX];
     int             bytes = -1;
+#endif
     int             i;
 
     for(i = 0; i < len; i++, data++)
@@ -59,6 +61,7 @@ vterm_render(vterm_t *vterm, char *data, int len)
             }
         }
 
+#ifndef NOUTF8
         if(!(vterm->flags & VTERM_FLAG_NOUTF8))
         {
             // UTF-8 encoding is indicated by a bit at 0x80
@@ -102,6 +105,7 @@ vterm_render(vterm_t *vterm, char *data, int len)
                 else continue;
             }
         }
+#endif
 
         if(IS_MODE_ESCAPED(vterm))
         {

--- a/vterm_utf8.c
+++ b/vterm_utf8.c
@@ -1,4 +1,4 @@
-
+#ifndef NOUTF8
 #include <string.h>
 #include <inttypes.h>
 #include <stdlib.h>
@@ -259,3 +259,4 @@ utf8_str_to_wchar(wchar_t *wch, const char *str, int max)
 
     return;
 }
+#endif

--- a/vterm_utf8.h
+++ b/vterm_utf8.h
@@ -1,3 +1,4 @@
+#ifndef NOUTF8
 #ifndef _VTERM_UTF8_H_
 #define _VTERM_UTF8_H_
 
@@ -21,4 +22,5 @@ void    vterm_utf8_cancel(vterm_t *vterm);
 
 int     vterm_utf8_decode(vterm_t *vterm, chtype *utf8_char, wchar_t *wch);
 
+#endif
 #endif


### PR DESCRIPTION
Automatic detection for UTF-8 is wrong for charsets like ISO 8859-1 (aka Latin-1). Because Latin-1 uses the 8th bit it would be miss-identified as bogus UTF-8 while it just needs to be passed through.
When dealing with legacy applications (not using UTF-8 but such Latin-1 charsets) one must be able to turn off UTF-8 in order to correctly interpret the output from them.