### PR TITLE
new API call to query cursor position

### DIFF
--- a/vterm.h
+++ b/vterm.h
@@ -680,6 +680,17 @@ void                vterm_resize_full(vterm_t *vterm,
 void                vterm_render(vterm_t *vterm, char *data, int len);
 
 /*
+    fetches the column and row of the current cursor position.
+
+    @params:
+        vterm           handle to a vterm object
+        column          a pointer to an integer where the column will be stored
+        row             a pointer to an integer where the row will be stored
+*/
+void                vterm_get_cursor_position (vterm_t *vterm,
+                        int *column, int *row);
+
+/*
     fetches the width and height of the current terminal dimentions.
 
     @params:

--- a/vterm_cursor.c
+++ b/vterm_cursor.c
@@ -164,3 +164,19 @@ vterm_cursor_restore(vterm_t *vterm)
 
     return;
 }
+
+void
+vterm_get_cursor_position(vterm_t *vterm, int *column, int *row)
+{
+    vterm_desc_t    *v_desc = NULL;
+    int             idx;
+
+    // set the vterm description buffer selector
+    idx = vterm_buffer_get_active(vterm);
+    v_desc = &vterm->vterm_desc[idx];
+
+    *column = v_desc->ccol;
+    *row = v_desc->crow;
+
+    return;
+}


### PR DESCRIPTION
If one is not using the ncurses API but is querying the buffer instead, there is currently no way to get the cursor position which might be of interest.