### PR TITLE
RFC: PoC C1 Control Sequences

### DIFF
--- a/vterm_ctrl_char.h
+++ b/vterm_ctrl_char.h
@@ -1,8 +1,12 @@
 #ifndef _VTERM_CTRL_CHAR_H_
 #define _VTERM_CTRL_CHAR_H_
 
-#define IS_CTRL_CHAR(x) \
+#define IS_C0(x) \
             ((unsigned int)x >= 1 && (unsigned int)x <= 31)
+#define IS_C1(x) \
+            ((unsigned int)x >= 128 && (unsigned int)x <= 159)
+#define IS_CTRL_CHAR(x) \
+            (IS_C0(x) || IS_C1(x))
 
 void    vterm_interpret_ctrl_char(vterm_t *vterm, char *data);
 

--- a/vterm_escape.c
+++ b/vterm_escape.c
@@ -67,7 +67,7 @@ vterm_interpret_escapes(vterm_t *vterm)
     char                firstchar;
     char                *lastchar;
 
-    static void         *interim_table[128] =
+    static void         *interim_table[160] =
                             {
                                 [0] = &&interim_char_none,
                                 [']'] = &&interim_OSC,
@@ -76,6 +76,10 @@ vterm_interpret_escapes(vterm_t *vterm)
                                 ['('] = &&interim_lparth,
                                 ['P'] = &&interim_char_P,
                                 ['#'] = &&interim_pound,
+                                // C1 Control Characters
+                                [0x90] = &&interim_char_P,
+                                [0x9b] = &&interim_CSI,
+                                [0x9d] = &&interim_OSC,
                             };
 
     int                 retval = 0;
@@ -105,7 +109,7 @@ vterm_interpret_escapes(vterm_t *vterm)
     retval = vterm_interpret_escapes_simple(vterm, firstchar);
     if(retval > 0) return;
 
-    SWITCH(interim_table, (unsigned int)firstchar, 0);
+    SWITCH(interim_table, (unsigned char)firstchar, 0);
 
     // looks like an complete xterm Operating System Command
     interim_OSC:

--- a/vterm_escape_simple.c
+++ b/vterm_escape_simple.c
@@ -8,7 +8,7 @@
 int
 vterm_interpret_escapes_simple(vterm_t *vterm, char verb)
 {
-    static void     *simple_table[128] =
+    static void     *simple_table[160] =
                         {
                             [0] = &&simple_char_default,
                             ['E'] = &&esc_NEL,
@@ -20,10 +20,14 @@ vterm_interpret_escapes_simple(vterm_t *vterm, char verb)
                             ['7'] = &&simple_char_vii,
                             ['8'] = &&simple_char_viii,
                             ['c'] = &&simple_char_c,
+                            // C1 Control Characters
+                            [0x84] = &&simple_IND,
+                            [0x85] = &&esc_NEL,
+                            [0x8d] = &&esc_RI,
                         };
 
 
-    SWITCH(simple_table, (unsigned int)verb, 0);
+    SWITCH(simple_table, (unsigned char)verb, 0);
 
     // interpert ESC-H a line-feed (NEL)
     esc_NEL:

--- a/vterm_render.c
+++ b/vterm_render.c
@@ -53,7 +53,7 @@ vterm_render(vterm_t *vterm, char *data, int len)
                 vterm_interpret_ctrl_char(vterm, data);
                 continue;
             }
-            else if(IS_C1((unsigned char)*data))
+            else if(!IS_MODE_UTF8(vterm) && IS_C1((unsigned char)*data))
             {
                 vterm_escape_start(vterm);
             }
@@ -87,12 +87,15 @@ vterm_render(vterm_t *vterm, char *data, int len)
 
             // we're done
             if(bytes > 0)
-            {
-                vterm_put_char(vterm, *data, wch);
-                vterm_utf8_cancel(vterm);
+            {   vterm_utf8_cancel(vterm);
+                if(bytes == 2 && IS_C1(wch[0])) vterm_escape_start(vterm);
+                else
+                {
+                    vterm_put_char(vterm, *data, wch);
+                    continue;
+                }
             }
-
-            continue;
+            else continue;
         }
 
         if(IS_MODE_ESCAPED(vterm))

--- a/vterm_render.c
+++ b/vterm_render.c
@@ -45,22 +45,24 @@ vterm_render(vterm_t *vterm, char *data, int len)
         // special processing looking for reset sequence
         if(vterm->rs1_reset != NULL) vterm->rs1_reset(vterm, (char *)data);
 
+
         if(!IS_MODE_ESCAPED(vterm))
         {
-            if(IS_CTRL_CHAR(*data))
+            if(IS_C0(*data))
             {
                 vterm_interpret_ctrl_char(vterm, data);
                 continue;
             }
+            else if(IS_C1((unsigned char)*data))
+            {
+                vterm_escape_start(vterm);
+            }
         }
 
         // UTF-8 encoding is indicated by a bit at 0x80
-        if((unsigned int)*data > 0x7F)
+        if((unsigned char)*data > 0x7F && !IS_MODE_UTF8(vterm) && !IS_C1((unsigned char)*data))
         {
-            if(!IS_MODE_UTF8(vterm))
-            {
-                vterm_utf8_start(vterm);
-            }
+            vterm_utf8_start(vterm);
         }
 
         if(IS_MODE_UTF8(vterm))


### PR DESCRIPTION
Issues I discovered:
- we have "char" in the codebase everywhere and sometimes casts to "unsigned int" which could be very wrong. we should migrate all places to "unsigned char". Then we can avoid casts at places where it counts.
- we do not handle UTF-8 (self) synchronization and probably by looking at the source handle such cases very badly.
- considering the set of C1 control sequences, the handling of ESC and control sequences should be merged as they are can be refered to from C1 at the same time. we should also get rid of the naming concept of "escape sequences" since with C1 we can start a control sequence without escape.

This pull request just shows a proof of concept embedding C1 in escape_simple and _osc and handling it like an "escape sequence".
Also see https://github.com/TragicWarrior/libvterm/issues/147