### PR TITLE
Move handling of color pairs to vterm_wnd_update

### DIFF
--- a/color_cache.c
+++ b/color_cache.c
@@ -448,6 +448,8 @@ vterm_set_colors(vterm_t *vterm, short fg, short bg)
     if(colors == -1) colors = 0;
 
     v_desc->default_colors = (short)colors;
+    v_desc->default_fg = fg;
+    v_desc->default_bg = bg;
 
     return 0;
 }

--- a/vterm.h
+++ b/vterm.h
@@ -77,13 +77,25 @@
     However, the only portable way to access that is via getcchar()
     and setcchar() which are a bit clumsy in their operation.
 */
+struct _vterm_color_s
+{   short           index;
+};
+
+typedef struct _vterm_color_s   vterm_color_t;
+
+#define VTERM_COLOR_INDEXED(n) \
+            (vterm_color_t) \
+            { \
+                .index = n, \
+            }
+
 struct _vterm_cell_s
 {
     wchar_t         wch[2];
     attr_t          attr;
     int             colors;
-    short           fg;
-    short           bg;
+    vterm_color_t   fg;
+    vterm_color_t   bg;
     short           f_rgb[3];
     short           b_rgb[3];
 };

--- a/vterm.h
+++ b/vterm.h
@@ -78,14 +78,27 @@
     and setcchar() which are a bit clumsy in their operation.
 */
 struct _vterm_color_s
-{   short           index;
+{
+    enum
+    {
+        VTERM_COLOR_TYPE_DEFAULT,
+        VTERM_COLOR_TYPE_INDEXED,
+    }
+                    type;
+    short           index;
 };
 
 typedef struct _vterm_color_s   vterm_color_t;
 
+#define VTERM_COLOR_DEFAULT \
+            (vterm_color_t) \
+            { \
+                .type = VTERM_COLOR_TYPE_DEFAULT, \
+            }
 #define VTERM_COLOR_INDEXED(n) \
             (vterm_color_t) \
             { \
+                .type = VTERM_COLOR_TYPE_INDEXED, \
                 .index = n, \
             }
 

--- a/vterm_buffer.c
+++ b/vterm_buffer.c
@@ -239,6 +239,10 @@ vterm_buffer_set_active(vterm_t *vterm, int idx)
         // copy some defaults from standard buffer
         v_desc->default_colors =
             vterm->vterm_desc[VTERM_BUF_STANDARD].default_colors;
+        v_desc->default_fg =
+            vterm->vterm_desc[VTERM_BUF_STANDARD].default_fg;
+        v_desc->default_bg =
+            vterm->vterm_desc[VTERM_BUF_STANDARD].default_bg;
 
         // erase the newly created buffer
         vterm_erase(vterm, idx, 0);

--- a/vterm_buffer.h
+++ b/vterm_buffer.h
@@ -57,10 +57,16 @@ int     vterm_buffer_clone(vterm_t *vterm, int src_idx, int dst_idx,
                 }
 
 #define VCELL_SET_DEFAULT_COLORS(_cell, _desc) \
-                { _cell.colors = _desc->default_colors; }
+                { \
+                    _cell.fg = VTERM_COLOR_DEFAULT; \
+                    _cell.bg = VTERM_COLOR_DEFAULT; \
+                }
 
-#define VCELL_GET_COLORS(_cell, _colors_ptr) \
-                { *_colors_ptr = _cell.colors; }
+#define VCELL_GET_COLORS(_cell, _fg_ptr, _bg_ptr) \
+                { \
+                    *_fg_ptr = _cell.fg; \
+                    *_bg_ptr = _cell.bg; \
+                }
 
 #endif
 

--- a/vterm_csi_SGR.c
+++ b/vterm_csi_SGR.c
@@ -163,10 +163,10 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
 
         csi_sgr_FG:
             // set fg color (case # - 30 = fg color)
-            v_desc->fg = param[i] - 30;
+            v_desc->fg = VTERM_COLOR_INDEXED(param[i] - 30);
 
-            _vterm_set_color_pair_safe(v_desc, vterm, -1, v_desc->fg,
-                v_desc->bg);
+            _vterm_set_color_pair_safe(v_desc, vterm, -1, v_desc->fg.index,
+                v_desc->bg.index);
 
             continue;
 
@@ -180,9 +180,9 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
 
             if(fg != -1)
             {
-                v_desc->fg = fg;
-                _vterm_set_color_pair_safe(v_desc, vterm, -1, v_desc->fg,
-                    v_desc->bg);
+                v_desc->fg = VTERM_COLOR_INDEXED(fg);
+                _vterm_set_color_pair_safe(v_desc, vterm, -1, v_desc->fg.index,
+                    v_desc->bg.index);
             }
 
             i += 2;
@@ -201,10 +201,10 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
             // reset fg color
             retval = color_cache_split_pair(v_desc->default_colors, &fg, &bg);
 
-            if(retval != -1) v_desc->fg = fg;
+            if(retval != -1) v_desc->fg = VTERM_COLOR_INDEXED(fg);
 
             _vterm_set_color_pair_safe(v_desc, vterm, retval != -1? -1: 0,
-                v_desc->fg, v_desc->bg);
+                v_desc->fg.index, v_desc->bg.index);
 
             if(param[i] != 0) continue;
 
@@ -213,19 +213,19 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
             // reset bg color
             retval = color_cache_split_pair(v_desc->default_colors, &fg, &bg);
 
-            if(retval != -1) v_desc->bg = bg;
+            if(retval != -1) v_desc->bg = VTERM_COLOR_INDEXED(bg);
 
             _vterm_set_color_pair_safe(v_desc, vterm, retval != -1? -1: 0,
-                v_desc->fg, v_desc->bg);
+                v_desc->fg.index, v_desc->bg.index);
 
             continue;
 
         csi_sgr_BG:
             // set bg color (case # - 40 = fg color)
-            v_desc->bg = param[i] - 40;
+            v_desc->bg = VTERM_COLOR_INDEXED(param[i] - 40);
 
-            _vterm_set_color_pair_safe(v_desc, vterm, -1, v_desc->fg,
-                v_desc->bg);
+            _vterm_set_color_pair_safe(v_desc, vterm, -1, v_desc->fg.index,
+                v_desc->bg.index);
 
             continue;
 
@@ -239,9 +239,9 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
 
             if(bg != -1)
             {
-                v_desc->bg = bg;
-                _vterm_set_color_pair_safe(v_desc, vterm, -1, v_desc->fg,
-                    v_desc->bg);
+                v_desc->bg = VTERM_COLOR_INDEXED(bg);
+                _vterm_set_color_pair_safe(v_desc, vterm, -1, v_desc->fg.index,
+                    v_desc->bg.index);
 
             }
 
@@ -255,20 +255,19 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
             if(vterm->flags & VTERM_FLAG_C16)
             {
                 fg = param[i] - 90;
-                v_desc->fg = vterm_add_mapped_color(vterm, fg + 90,
-                    rRGB[fg], gRGB[fg], bRGB[fg]);
+                v_desc->fg = VTERM_COLOR_INDEXED(vterm_add_mapped_color(vterm,
+                    fg + 90, rRGB[fg], gRGB[fg], bRGB[fg]));
             }
             else
             {
-                if(vterm->flags & VTERM_FLAG_C8) v_desc->fg = param[i] - 90;
+                if(vterm->flags & VTERM_FLAG_C8)
+                    v_desc->fg = VTERM_COLOR_INDEXED(param[i] - 90);
                 else
-                {
-                    v_desc->fg = (param[i] - 90) + 8;
-                }
+                    v_desc->fg = VTERM_COLOR_INDEXED((param[i] - 90) + 8);
             }
 
-            _vterm_set_color_pair_safe(v_desc, vterm, -1, v_desc->fg,
-                v_desc->bg);
+            _vterm_set_color_pair_safe(v_desc, vterm, -1, v_desc->fg.index,
+                v_desc->bg.index);
 
             continue;
 
@@ -278,17 +277,17 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
             if(vterm->flags & VTERM_FLAG_C16)
             {
                 bg = param[i] - 100;
-                v_desc->bg = vterm_add_mapped_color(vterm, bg + 100,
-                    rRGB[bg], gRGB[bg], bRGB[bg]);
+                v_desc->bg = VTERM_COLOR_INDEXED(vterm_add_mapped_color(vterm,
+                    bg + 100, rRGB[bg], gRGB[bg], bRGB[bg]));
             }
             else
             {
-                v_desc->bg = param[i] - 100;
-                if((vterm->flags & VTERM_FLAG_C8) == 0) v_desc->bg += 8;
+                v_desc->bg = VTERM_COLOR_INDEXED(param[i] - 100);
+                if((vterm->flags & VTERM_FLAG_C8) == 0) v_desc->bg.index += 8;
             }
 
-            _vterm_set_color_pair_safe(v_desc, vterm, -1, v_desc->fg,
-                v_desc->bg);
+            _vterm_set_color_pair_safe(v_desc, vterm, -1, v_desc->fg.index,
+                v_desc->bg.index);
 
             continue;
 

--- a/vterm_private.h
+++ b/vterm_private.h
@@ -105,6 +105,8 @@ struct _vterm_desc_s
     int             colors;                     // current color pair
 
     int             default_colors;             // default fg/bg color pair
+    int             default_fg;                 // default foreground color
+    int             default_bg;                 // default background color
 
     int             ccol;                       // current cursor col
     int             crow;                       // current cursor row

--- a/vterm_private.h
+++ b/vterm_private.h
@@ -117,8 +117,8 @@ struct _vterm_desc_s
 
     int             saved_x, saved_y;           // saved cursor coords
 
-    int             fg;                         // current fg color
-    int             bg;                         // current bg color
+    vterm_color_t   fg;                         // current fg color
+    vterm_color_t   bg;                         // current bg color
     short           f_rgb[3];                   // current fg RGB values
     short           b_rgb[3];                   // current bg RGB values
 };


### PR DESCRIPTION
This PR is the first of many changes to come that restructures the color handling, to decouple the colors of the guest application from the colors of output front end (currently only ncurses in vterm_wnd_update).
Next I would slowly also move the "ncurses output" side of the color map. In the longterm however we would need two different maps:
- the first would map a (guest) color number to a RGB value
- the second would map a RGB value to a color number (for ncurses front end output)
This is also in regard to different front ends which might not rely on ncurses or color pairs at all.

Also note that I introduced a concept of a symbolic default color which has several advantages:
- one can change the default colors (for output) at any time
- we can distinguish default colors from colors with the same value
- therefore different front ends can have different default colors attached to the same libvterm backend at the same time.

The RGB values of vcell were set and exposed before, but not used. With this PR they will be made locally available but not preserved in vcell (yet). In the long term, we will a RGB type for "direct colors" (as opposed to "indexed colors") that will preserve the information of a mapped RGB color in vcell.

I tested all the individual commits with ponysay/xterm-256color for functionality. I cannot attest for performance but I presume it is not worse but probably better than before.