### PR TITLE
Minor cmake refactor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+9.4
+
+* [Sioryn Willett] now installs libvtermConfig.cmake 
+  which enables find_package(libvterm) in cmake projects
+
 9.3
 
 * [Bryan Christ] Added support for anonymous colors which are used by

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ add_library(vterm-static STATIC
     vterm_write.c
     stringv.c
     )
+set_target_properties(vterm-static PROPERTIES PUBLIC_HEADER "vterm.h")
 
 add_library(vterm.o OBJECT
     color_cache.c
@@ -182,6 +183,7 @@ add_library(vterm.o OBJECT
     vterm_write.c
     stringv.c
     )
+set_target_properties(vterm-static PROPERTIES PUBLIC_HEADER "vterm.h")
 
 add_library(vterm-shared SHARED
     $<TARGET_OBJECTS:vterm.o>
@@ -329,6 +331,7 @@ install (TARGETS vterm-static vterm-shared
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin
         INCLUDES DESTINATION include
+        PUBLIC_HEADER DESTINATION include
         )
 
 include(CMakePackageConfigHelpers)
@@ -337,8 +340,6 @@ write_basic_package_version_file(
         VERSION ${PACKAGE_VERSION}
         COMPATIBILITY AnyNewerVersion
 )
-
-install (FILES vterm.h DESTINATION include)
 
 install(EXPORT libvtermTargets
         FILE libvtermTargets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.10.2)
 
 project(libvterm C)
 set(MAJOR_VERSION 9)
-set(MINOR_VERSION 3)
+set(MINOR_VERSION 4)
 
 message("CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,8 +323,29 @@ if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
 
 endif()
 
-install (TARGETS vterm-static vterm-shared DESTINATION lib)
+install (TARGETS vterm-static vterm-shared
+        EXPORT libvtermTargets
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include
+        )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+        libvtermConfigVersion.cmake
+        VERSION ${PACKAGE_VERSION}
+        COMPATIBILITY AnyNewerVersion
+)
+
 install (FILES vterm.h DESTINATION include)
+
+install(EXPORT libvtermTargets
+        FILE libvtermTargets.cmake
+        NAMESPACE libvterm::
+        DESTINATION lib/cmake/libvterm
+        )
+
 
 # Install pkgconfig files to libdata on BSD, otherwise lib
 if(CMAKE_SYSTEM_NAME MATCHES "BSD")
@@ -333,6 +354,12 @@ else()
     set(PKG_CONFIG_INSTALL_DIR "lib/pkgconfig")
 endif()
 install (FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.pc" DESTINATION ${PKG_CONFIG_INSTALL_DIR})
+
+configure_file(libvtermConfig.cmake.in libvtermConfig.cmake @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libvtermConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/libvtermConfigVersion.cmake"
+        DESTINATION lib/cmake/libvterm
+        )
 
 set(CPACK_GENERATOR "DEB;RPM")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Bryan")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,231 +57,76 @@ endif()
 
 find_package(Curses)
 
-add_library(vterm-static STATIC
-    color_cache.c
-    color_math.c
-    color_map.c
-    mouse_driver.c
-    mouse_driver_X10.c
-    mouse_driver_SGR.c
-    nc_wrapper.c
-    vterm.c
-    vterm_aio.c
-    vterm_ctrl_char.c
-    vterm_csi.c
-    vterm_exec.c
-    vterm_erase.c
-    vterm_error.c
-    vterm_escape.c
-    vterm_escape_simple.c
-    vterm_escape_suffixes.c
-    vterm_buffer.c
-    vterm_csi_CBT.c
-    vterm_csi_CUP.c
-    vterm_csi_CUx.c
-    vterm_csi_DCH.c
-    vterm_csi_DECSTBM.c
-    vterm_csi_DL.c
-    vterm_csi_ECH.c
-    vterm_csi_ED.c
-    vterm_csi_EL.c
-    vterm_csi_ICH.c
-    vterm_csi_IL.c
-    vterm_csi_IRM.c
-    vterm_csi_RESTORECUR.c
-    vterm_csi_REP.c
-    vterm_csi_RS1.c
-    vterm_csi_SAVECUR.c
-    vterm_csi_SD.c
-    vterm_csi_SGR.c
-    vterm_csi_SU.c
-    vterm_csi_UNKNOWN.c
-    vterm_cursor.c
-    vterm_dec_DECALN.c
-    vterm_dec_RM.c
-    vterm_dec_SM.c
-    vterm_esc_IND.c
-    vterm_esc_NEL.c
-    vterm_esc_RI.c
-    vterm_history.c
-    vterm_hook.c
-    vterm_misc.c
-    vterm_osc.c
-    vterm_osc_DA.c
-    vterm_read.c
-    vterm_render.c
-    vterm_reply.c
-    vterm_resize.c
-    vterm_scroll.c
-    vterm_userptr.c
-    vterm_utf8.c
-    vterm_wnd.c
-    vterm_write.c
-    stringv.c
-    )
+set(SRC_FILES color_cache.c
+        color_math.c
+        color_map.c
+        mouse_driver.c
+        mouse_driver_X10.c
+        mouse_driver_SGR.c
+        nc_wrapper.c
+        vterm.c
+        vterm_aio.c
+        vterm_ctrl_char.c
+        vterm_csi.c
+        vterm_exec.c
+        vterm_erase.c
+        vterm_error.c
+        vterm_escape.c
+        vterm_escape_simple.c
+        vterm_escape_suffixes.c
+        vterm_buffer.c
+        vterm_csi_CBT.c
+        vterm_csi_CUP.c
+        vterm_csi_CUx.c
+        vterm_csi_DCH.c
+        vterm_csi_DECSTBM.c
+        vterm_csi_DL.c
+        vterm_csi_ECH.c
+        vterm_csi_ED.c
+        vterm_csi_EL.c
+        vterm_csi_ICH.c
+        vterm_csi_IL.c
+        vterm_csi_IRM.c
+        vterm_csi_RESTORECUR.c
+        vterm_csi_REP.c
+        vterm_csi_RS1.c
+        vterm_csi_SAVECUR.c
+        vterm_csi_SD.c
+        vterm_csi_SGR.c
+        vterm_csi_SU.c
+        vterm_csi_UNKNOWN.c
+        vterm_cursor.c
+        vterm_dec_DECALN.c
+        vterm_dec_RM.c
+        vterm_dec_SM.c
+        vterm_esc_IND.c
+        vterm_esc_NEL.c
+        vterm_esc_RI.c
+        vterm_history.c
+        vterm_hook.c
+        vterm_misc.c
+        vterm_osc.c
+        vterm_osc_DA.c
+        vterm_read.c
+        vterm_render.c
+        vterm_reply.c
+        vterm_resize.c
+        vterm_scroll.c
+        vterm_userptr.c
+        vterm_utf8.c
+        vterm_wnd.c
+        vterm_write.c
+        stringv.c)
+
+add_library(vterm-static STATIC ${SRC_FILES})
 set_target_properties(vterm-static PROPERTIES PUBLIC_HEADER "vterm.h")
 
-add_library(vterm.o OBJECT
-    color_cache.c
-    color_math.c
-    color_map.c
-    mouse_driver.c
-    mouse_driver_X10.c
-    mouse_driver_SGR.c
-    nc_wrapper.c
-    vterm.c
-    vterm_aio.c
-    vterm_buffer.c
-    vterm_ctrl_char.c
-    vterm_csi.c
-    vterm_erase.c
-    vterm_error.c
-    vterm_escape.c
-    vterm_escape_simple.c
-    vterm_escape_suffixes.c
-    vterm_exec.c
-    vterm_csi_CBT.c
-    vterm_csi_CUP.c
-    vterm_csi_CUx.c
-    vterm_csi_DCH.c
-    vterm_csi_DECSTBM.c
-    vterm_csi_DL.c
-    vterm_csi_ECH.c
-    vterm_csi_ED.c
-    vterm_csi_EL.c
-    vterm_csi_ICH.c
-    vterm_csi_IL.c
-    vterm_csi_IRM.c
-    vterm_csi_RESTORECUR.c
-    vterm_csi_REP.c
-    vterm_csi_RS1.c
-    vterm_csi_SAVECUR.c
-    vterm_csi_SD.c
-    vterm_csi_SGR.c
-    vterm_csi_SU.c
-    vterm_csi_UNKNOWN.c
-    vterm_cursor.c
-    vterm_dec_DECALN.c
-    vterm_dec_RM.c
-    vterm_dec_SM.c
-    vterm_esc_IND.c
-    vterm_esc_NEL.c
-    vterm_esc_RI.c
-    vterm_history.c
-    vterm_hook.c
-    vterm_misc.c
-    vterm_osc.c
-    vterm_osc_DA.c
-    vterm_read.c
-    vterm_render.c
-    vterm_reply.c
-    vterm_resize.c
-    vterm_scroll.c
-    vterm_userptr.c
-    vterm_utf8.c
-    vterm_wnd.c
-    vterm_write.c
-    stringv.c
-    )
+add_library(vterm.o OBJECT ${SRC_FILES})
 set_target_properties(vterm-static PROPERTIES PUBLIC_HEADER "vterm.h")
 
-add_library(vterm-shared SHARED
-    $<TARGET_OBJECTS:vterm.o>
-    )
+add_library(vterm-shared SHARED $<TARGET_OBJECTS:vterm.o>)
 
-
-if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-
-    if (Curses_FOUND)
-        if(DEFINE_CURSES)
-            add_executable(vshell
-                demo/vshell.c
-                demo/ctimer.c
-                )
-        endif(DEFINE_CURSES)
-    endif()
-
-
-    if ((Curses_FOUND) AND (DEFINE_CURSES))
-        target_link_libraries(
-                    vshell
-                    vterm-shared
-                    vterm-static
-                    -lutil
-                    -lm
-                    -lrt
-                    -ldl
-                    ${CURSES_LIBRARIES})
-    else()
-        target_link_libraries(
-                    vterm-shared
-                    vterm-static
-                    -lutil
-                    -lm
-                    -lrt
-                    -ldl
-                    ${CURSES_LIBRARIES})
-    endif()
-endif()
-
-if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
-
-    if(DEFINE_CURSES)
-        add_executable(vshell
-            demo/vshell.c
-            demo/ctimer.c
-            )
-    endif(DEFINE_CURSES)
-
-    if (DEFINE_CURSES)
-        target_link_libraries(
-                    vshell
-                    vterm-shared
-                    vterm-static
-                    -lc
-                    -lutil
-                    -lm
-                    -lncursesw)
-    else()
-
-        target_link_libraries(
-                    vterm-shared
-                    vterm-static
-                    -lc
-                    -lutil
-                    -lm
-                    -lncursesw)
-    endif()
-endif()
-
-if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-
-    if(DEFINE_CURSES)
-        add_executable(vshell
-            demo/vshell.c
-            demo/ctimer.c
-            )
-    endif(DEFINE_CURSES)
-
-    #link_directories(/usr/local/opt/ncurses/lib/)
-
-    if (DEFINE_CURSES)
-        target_link_libraries(
-                    vshell
-                    vterm-shared
-                    vterm-static
-                    -lutil
-                    -lm
-                    /usr/local/opt/ncurses/lib/libncursesw.dylib)
-    else()
-        target_link_libraries(
-                    vterm-shared
-                    vterm-static
-                    -lutil
-                    -lm)
-    endif()
-endif()
-
+add_subdirectory(demo)
 
 # CMake doesn't allow targets with the same name.  This renames them properly afterward.
 SET_TARGET_PROPERTIES(vterm-static PROPERTIES OUTPUT_NAME vterm CLEAN_DIRECT_OUTPUT 1)
@@ -298,32 +143,6 @@ configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/pkg-config.pc.cmake"
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc"
 )
-
-if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-
-    if (Curses_FOUND)
-        if(DEFINE_CURSES)
-            install (TARGETS vshell DESTINATION bin)
-        endif(DEFINE_CURSES)
-    endif()
-
-endif()
-
-if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
-
-    if(DEFINE_CURSES)
-        install (TARGETS vshell DESTINATION bin)
-    endif(DEFINE_CURSES)
-
-endif()
-
-if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-
-    if(DEFINE_CURSES)
-        install (TARGETS vshell DESTINATION bin)
-    endif(DEFINE_CURSES)
-
-endif()
 
 install (TARGETS vterm-static vterm-shared
         EXPORT libvtermTargets

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,0 +1,117 @@
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+
+    if (Curses_FOUND)
+        if(DEFINE_CURSES)
+            add_executable(vshell
+                    demo/vshell.c
+                    demo/ctimer.c
+                    )
+        endif(DEFINE_CURSES)
+    endif()
+
+
+    if ((Curses_FOUND) AND (DEFINE_CURSES))
+        target_link_libraries(
+                vshell
+                vterm-shared
+                vterm-static
+                -lutil
+                -lm
+                -lrt
+                -ldl
+                ${CURSES_LIBRARIES})
+    else()
+        target_link_libraries(
+                vterm-shared
+                vterm-static
+                -lutil
+                -lm
+                -lrt
+                -ldl
+                ${CURSES_LIBRARIES})
+    endif()
+endif()
+
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
+
+    if(DEFINE_CURSES)
+        add_executable(vshell
+                demo/vshell.c
+                demo/ctimer.c
+                )
+    endif(DEFINE_CURSES)
+
+    if (DEFINE_CURSES)
+        target_link_libraries(
+                vshell
+                vterm-shared
+                vterm-static
+                -lc
+                -lutil
+                -lm
+                -lncursesw)
+    else()
+
+        target_link_libraries(
+                vterm-shared
+                vterm-static
+                -lc
+                -lutil
+                -lm
+                -lncursesw)
+    endif()
+endif()
+
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+
+    if(DEFINE_CURSES)
+        add_executable(vshell
+                vshell.c
+                ctimer.c
+                )
+    endif(DEFINE_CURSES)
+
+    #link_directories(/usr/local/opt/ncurses/lib/)
+
+    if (DEFINE_CURSES)
+        target_link_libraries(
+                vshell
+                vterm-shared
+                vterm-static
+                -lutil
+                -lm
+                /usr/local/opt/ncurses/lib/libncursesw.dylib)
+    else()
+        target_link_libraries(
+                vterm-shared
+                vterm-static
+                -lutil
+                -lm)
+    endif()
+endif()
+
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+
+    if (Curses_FOUND)
+        if(DEFINE_CURSES)
+            install (TARGETS vshell DESTINATION bin)
+        endif(DEFINE_CURSES)
+    endif()
+
+endif()
+
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
+
+    if(DEFINE_CURSES)
+        install (TARGETS vshell DESTINATION bin)
+    endif(DEFINE_CURSES)
+
+endif()
+
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+
+    if(DEFINE_CURSES)
+        install (TARGETS vshell DESTINATION bin)
+    endif(DEFINE_CURSES)
+
+endif()

--- a/libvtermConfig.cmake.in
+++ b/libvtermConfig.cmake.in
@@ -1,0 +1,11 @@
+include(CMakeFindDependencyMacro)
+
+## Same syntax as find_package
+find_dependency(Curses REQUIRED)
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+    include_directories(/usr/local/opt/ncurses/include)
+    link_directories(/usr/local/opt/ncurses/lib)
+endif() 
+
+# Add the targets file
+include("${CMAKE_CURRENT_LIST_DIR}/libvtermTargets.cmake")


### PR DESCRIPTION
Hey I've been using this in a pet project of mine,
I was strugglling with installing/including it nicely in another cmake project so:

I've updated it so that the libraries can easily be acquired with find_package() using the cmake installation's default paths
It works on macOS with ncurses installed via homebrew.
I'm yet to test it out on linux/BSD/Windows, however the previous packaging system was left unchanged, so it shouldn't be any less portable.

I also put the demo into it's own CMakeLists.txt, as it felt right.