### PR TITLE
cache active buffer descriptor pointer

### DIFF
--- a/color_cache.c
+++ b/color_cache.c
@@ -433,13 +433,11 @@ vterm_set_colors(vterm_t *vterm, short fg, short bg)
 {
     vterm_desc_t    *v_desc = NULL;
     long            colors;
-    int             idx;
 
     if(vterm == NULL) return -1;
 
     // set vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
 #ifdef NOCURSES
     if(has_colors() == FALSE) return -1;
@@ -457,13 +455,11 @@ long
 vterm_get_colors(vterm_t *vterm)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
 
     if(vterm == NULL) return -1;
 
     // set vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
 #ifndef NOCURSES
         if(has_colors() == FALSE) return -1;

--- a/vterm.c
+++ b/vterm.c
@@ -90,6 +90,11 @@ vterm_init(vterm_t *vterm, uint16_t width, uint16_t height, uint32_t flags)
     if(vterm == NULL)
         vterm = (vterm_t*)calloc(1, sizeof(vterm_t));
 
+    // seed the active descriptor cache.  vterm_desc_idx defaults to 0
+    // (VTERM_BUF_STANDARD) from calloc; the inline array address is stable
+    // for the lifetime of the vterm_t.
+    vterm->v_desc_active = &vterm->vterm_desc[VTERM_BUF_STANDARD];
+
     // allocate a the buffer (a matrix of cells)
     vterm_buffer_alloc(vterm, VTERM_BUF_STANDARD, width, height);
 

--- a/vterm_buffer.c
+++ b/vterm_buffer.c
@@ -257,9 +257,11 @@ vterm_buffer_set_active(vterm_t *vterm, int idx)
         vterm_erase(vterm, idx, 0);
     }
 
-    // update the vterm buffer desc index
+    // update the vterm buffer desc index and the cached active pointer.
+    // these two MUST stay in sync -- v_desc_active is read on hot paths.
     vterm->vterm_desc_idx = idx;
-    v_desc = &vterm->vterm_desc[idx];
+    vterm->v_desc_active = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
     VCELL_ALL_SET_DIRTY(v_desc);
 
     // run the event hook if installed
@@ -425,15 +427,13 @@ vterm_copy_buffer(vterm_t *vterm, int *rows, int *cols)
 {
     vterm_desc_t    *v_desc = NULL;
     vterm_cell_t    **buffer;
-    int             idx;
     int             r;
 
     if(vterm == NULL) return NULL;
     if(rows == NULL || cols == NULL) return NULL;
 
     // set vterm desc buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     *rows = v_desc->rows;
     *cols = v_desc->max_cols;

--- a/vterm_csi_CBT.c
+++ b/vterm_csi_CBT.c
@@ -15,15 +15,13 @@ interpret_csi_CBT(vterm_t *vterm, int param[], int pcount)
     vterm_desc_t    *v_desc = NULL;
     int             tab_count = 1;          // default is one
     int             stride;
-    int             idx;
 
     if(vterm == NULL) return;
 
     if(pcount > 0) tab_count = param[0];
 
     // set the vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     stride = v_desc->ccol % 8;
 

--- a/vterm_csi_CUP.c
+++ b/vterm_csi_CUP.c
@@ -14,11 +14,9 @@ void
 interpret_csi_CUP(vterm_t *vterm, int param[], int pcount)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
 
     // set active vterm description selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     if (pcount == 0)
     {

--- a/vterm_csi_CUx.c
+++ b/vterm_csi_CUx.c
@@ -36,7 +36,6 @@ void
 interpret_csi_CUx(vterm_t *vterm, char verb, int param[], int pcount)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
     int             n = 1;
     static void     *curmove_table[] =
                         {
@@ -62,8 +61,7 @@ interpret_csi_CUx(vterm_t *vterm, char verb, int param[], int pcount)
     }
 
     // set active vterm description selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     SWITCH(curmove_table, (unsigned int)verb, 0);
 

--- a/vterm_csi_DCH.c
+++ b/vterm_csi_DCH.c
@@ -13,15 +13,13 @@ interpret_csi_DCH(vterm_t *vterm, int param[], int pcount)
     vterm_cell_t    *vcell_src;
     vterm_cell_t    *vcell_dst;
     int             stride;
-    int             idx;
     int             n = 1;
     int             c;
 
     if(pcount && param[0] > 0) n = param[0];
 
     // select the correct desc
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     stride = v_desc->cols - v_desc->ccol;
     stride -= n;

--- a/vterm_csi_DECSTBM.c
+++ b/vterm_csi_DECSTBM.c
@@ -17,11 +17,9 @@ interpret_csi_DECSTBM(vterm_t *vterm,int param[],int pcount)
 {
     vterm_desc_t    *v_desc = NULL;
     int             newtop, newbottom;
-    int             idx;
 
     // set the vterm description selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     if(!pcount)
     {

--- a/vterm_csi_DL.c
+++ b/vterm_csi_DL.c
@@ -14,11 +14,9 @@ interpret_csi_DL(vterm_t *vterm, int param[], int pcount)
     vterm_desc_t    *v_desc = NULL;
     int             c, r;
     int             n = 1;
-    int             idx;
 
     // set selector for buffer description
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     if(pcount && param[0] > 0) n = param[0];
 

--- a/vterm_csi_ECH.c
+++ b/vterm_csi_ECH.c
@@ -12,12 +12,10 @@ interpret_csi_ECH(vterm_t *vterm, int param[], int pcount)
     vterm_desc_t    *v_desc = NULL;
     int             c;
     int             n = 1;
-    int             idx;
     int             max_col;
 
     // set vterm descipton buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     if(pcount && param[0] > 0) n = param[0];
 

--- a/vterm_csi_ED.c
+++ b/vterm_csi_ED.c
@@ -29,13 +29,11 @@ interpret_csi_ED(vterm_t *vterm, int param[], int pcount)
     vterm_desc_t    *v_desc = NULL;
     int             r, c;
     int             start_row, start_col, end_row, end_col;
-    int             idx;
 
     unsigned int    p;
 
     // set vterm desc buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     p = (pcount > 0 ? param[0] : 3);
 

--- a/vterm_csi_EL.c
+++ b/vterm_csi_EL.c
@@ -34,12 +34,10 @@ interpret_csi_EL(vterm_t *vterm, int param[], int pcount)
     vterm_desc_t    *v_desc = NULL;
     int             erase_start, erase_end, c;
     int             cmd = 0;
-    int             idx;
     int             row;
 
     // set the vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     cmd =  (pcount > 0 ? param[0] : 0);
 

--- a/vterm_csi_ICH.c
+++ b/vterm_csi_ICH.c
@@ -13,14 +13,12 @@ interpret_csi_ICH(vterm_t *vterm, int param[], int pcount)
     vterm_desc_t    *v_desc = NULL;
     int             c;
     int             n = 1;
-    int             idx;
     int             max_stride;
     int             max_col;
     int             scr_end;
 
     // set the vterm desciption selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     if(pcount && param[0] > 0) n = param[0];
 

--- a/vterm_csi_IL.c
+++ b/vterm_csi_IL.c
@@ -14,11 +14,9 @@ interpret_csi_IL(vterm_t *vterm,int param[],int pcount)
     vterm_desc_t    *v_desc = NULL;
     int             r, c;
     int             n = 1;
-    int             idx;
 
     // set vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     if(pcount && param[0] > 0) n = param[0];
 

--- a/vterm_csi_REP.c
+++ b/vterm_csi_REP.c
@@ -16,15 +16,13 @@ interpret_csi_REP(vterm_t *vterm, int param[], int pcount)
     vterm_cell_t    *vcell_prev;
     vterm_cell_t    *vcell;
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
     int             max_col;
     int             c;
 
     if(vterm == NULL) return;
 
     // set the vterm desciption selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     // if repeat value isn't supplied, return.  nothing to do.
     if(pcount == 0) return;

--- a/vterm_csi_RESTORECUR.c
+++ b/vterm_csi_RESTORECUR.c
@@ -9,14 +9,12 @@ void
 interpret_csi_RESTORECUR(vterm_t *vterm, int param[], int pcount)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
 
     VAR_UNUSED(param);
     VAR_UNUSED(pcount);
 
     // set the vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     v_desc->ccol = v_desc->saved_x;
     v_desc->crow = v_desc->saved_y;

--- a/vterm_csi_SAVECUR.c
+++ b/vterm_csi_SAVECUR.c
@@ -9,14 +9,12 @@ void
 interpret_csi_SAVECUR(vterm_t *vterm, int param[], int pcount)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
 
     VAR_UNUSED(param);    //make compiler happy
     VAR_UNUSED(pcount);
 
     // set vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     v_desc->saved_x = v_desc->ccol;
     v_desc->saved_y = v_desc->crow;

--- a/vterm_csi_SD.c
+++ b/vterm_csi_SD.c
@@ -22,15 +22,13 @@ interpret_csi_SD(vterm_t *vterm, int param[], int pcount)
     vterm_cell_t    *vcell;
     int             r;
     int             n = 1;          // number of scroll lines
-    int             idx;
     int             bottom_row;
     int             top_row;
     int             stride;
     int             c;
 
     // set selector for buffer description
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     if(pcount > 0)
     {

--- a/vterm_csi_SGR.c
+++ b/vterm_csi_SGR.c
@@ -52,7 +52,6 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
     int             i;
     short           mapped_color;
     int             processed = 0;
-    int             idx;
     short           fg, bg;
     int             retval;
     static void     *sgr_table[] =
@@ -83,8 +82,7 @@ interpret_csi_SGR(vterm_t *vterm, int param[], int pcount)
                         };
 
     // set vterm_desc buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     if(pcount == 0)
     {

--- a/vterm_csi_SU.c
+++ b/vterm_csi_SU.c
@@ -22,15 +22,13 @@ interpret_csi_SU(vterm_t *vterm, int param[], int pcount)
     vterm_cell_t    *vcell;
     int             r;
     int             n = 1;          // number of scroll lines
-    int             idx;
     int             bottom_row;
     int             top_row;
     int             stride;
     int             i;
 
     // set selector for buffer description
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     if(pcount > 0)
     {

--- a/vterm_ctrl_char.c
+++ b/vterm_ctrl_char.c
@@ -30,9 +30,9 @@ vterm_interpret_ctrl_char(vterm_t *vterm, char *data)
                             ['\a']      = &&ctrl_char_BELL,
                         };
 
-    // set vterm desc buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    // active buffer descriptor (idx kept for VTERM_BUF_ALTERNATE compare below)
+    idx = vterm->vterm_desc_idx;
+    v_desc = vterm->v_desc_active;
 
     verb = data[0];
 

--- a/vterm_cursor.c
+++ b/vterm_cursor.c
@@ -13,11 +13,9 @@ void
 vterm_cursor_move_home(vterm_t *vterm)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
 
     // set vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     v_desc->ccol = 0;
 
@@ -38,11 +36,9 @@ vterm_cursor_move_backward(vterm_t *vterm)
 {
     vterm_desc_t    *v_desc = NULL;
     int             min_row;
-    int             idx;
 
     // set vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     if(v_desc->buffer_state & STATE_ORIGIN_MODE)
         min_row = v_desc->scroll_min;
@@ -69,12 +65,10 @@ void
 vterm_cursor_move_tab(vterm_t *vterm)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
     int             tab_sz = 8;
 
     // set vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     // a tab on the last column push to the beginning of the next row
     if(v_desc->ccol == v_desc->cols - 1)
@@ -144,11 +138,9 @@ void
 vterm_cursor_save(vterm_t *vterm)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
 
     // set vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     v_desc->saved_x = v_desc->ccol;
     v_desc->saved_y = v_desc->crow;
@@ -160,11 +152,9 @@ void
 vterm_cursor_restore(vterm_t *vterm)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
 
     // set the vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     v_desc->ccol = v_desc->saved_x;
     v_desc->crow = v_desc->saved_y;
@@ -176,11 +166,9 @@ void
 vterm_get_cursor_position(vterm_t *vterm, int *column, int *row)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
 
     // set the vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     *column = v_desc->ccol;
     *row = v_desc->crow;

--- a/vterm_dec_DECALN.c
+++ b/vterm_dec_DECALN.c
@@ -16,12 +16,10 @@ interpret_dec_DECALN(vterm_t *vterm)
 {
     vterm_desc_t    *v_desc = NULL;
     vterm_cell_t    *vcell;
-    int             idx;
     int             r, c;
 
     // set the vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     for(r = 0;r < v_desc->rows; r++)
     {

--- a/vterm_dec_RM.c
+++ b/vterm_dec_RM.c
@@ -21,9 +21,9 @@ interpret_dec_RM(vterm_t *vterm, int param[], int pcount)
 
     if(pcount == 0) return;
 
-    // set vterm desc buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    // active buffer descriptor (idx kept for VTERM_BUF_* compares below)
+    idx = vterm->vterm_desc_idx;
+    v_desc = vterm->v_desc_active;
 
     for(i = 0; i < pcount; i++)
     {

--- a/vterm_dec_SM.c
+++ b/vterm_dec_SM.c
@@ -24,9 +24,9 @@ interpret_dec_SM(vterm_t *vterm, int param[], int pcount)
 
     if(pcount == 0) return;
 
-    // set the vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    // active buffer descriptor (idx kept for cursor_show / VTERM_BUF_ALTERNATE compares)
+    idx = vterm->vterm_desc_idx;
+    v_desc = vterm->v_desc_active;
 
     for(i = 0; i < pcount; i++)
     {

--- a/vterm_erase.c
+++ b/vterm_erase.c
@@ -19,11 +19,12 @@ vterm_erase(vterm_t *vterm, int idx, char fill_char)
     // a value of -1 means current, active buffer
     if(idx == -1)
     {
-        // set the vterm description buffer selector
-        idx = vterm_buffer_get_active(vterm);
+        v_desc = vterm->v_desc_active;
     }
-
-    v_desc = &vterm->vterm_desc[idx];
+    else
+    {
+        v_desc = &vterm->vterm_desc[idx];
+    }
 
     // post event that term is about to be erased
     if(vterm->event_mask & VTERM_MASK_TERM_PRECLEAR)
@@ -58,15 +59,13 @@ vterm_erase_row(vterm_t *vterm, int row, bool reset_colors, char fill_char)
     vterm_cell_t    *vcell;
     vterm_desc_t    *v_desc = NULL;
     int             c;
-    int             idx;
 
     if(vterm == NULL) return;
 
     if(fill_char == 0) fill_char = ' ';
 
     // set the vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     if(row == -1) row = v_desc->crow;
     vcell = &v_desc->cells[row][0];
@@ -89,7 +88,6 @@ void
 vterm_erase_rows(vterm_t *vterm, int start_row, char fill_char)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
 
     if(vterm == NULL) return;
     if(start_row < 0) return;
@@ -97,8 +95,7 @@ vterm_erase_rows(vterm_t *vterm, int start_row, char fill_char)
     if(fill_char == 0) fill_char = ' ';
 
     // set the vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     while(start_row < v_desc->rows)
     {
@@ -114,7 +111,6 @@ vterm_erase_col(vterm_t *vterm, int col, char fill_char)
 {
     vterm_cell_t    *vcell;
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
     int             r;
 
     if(vterm == NULL) return;
@@ -122,8 +118,7 @@ vterm_erase_col(vterm_t *vterm, int col, char fill_char)
     if(fill_char == 0) fill_char = ' ';
 
     // set the vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     if(col == -1) col = v_desc->ccol;
 
@@ -144,7 +139,6 @@ void
 vterm_erase_cols(vterm_t *vterm, int start_col, char fill_char)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
 
     if(vterm == NULL) return;
     if(start_col < 0) return;
@@ -152,8 +146,7 @@ vterm_erase_cols(vterm_t *vterm, int start_col, char fill_char)
     if(fill_char == 0) fill_char = ' ';
 
     // set the vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     while(start_col < v_desc->cols)
     {

--- a/vterm_esc_NEL.c
+++ b/vterm_esc_NEL.c
@@ -23,11 +23,9 @@ inline void
 interpret_esc_NEL(vterm_t *vterm)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
 
     // set vterm desc buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     // move to column 1;
     v_desc->ccol = 0;

--- a/vterm_esc_RI.c
+++ b/vterm_esc_RI.c
@@ -23,11 +23,9 @@ inline void
 interpret_esc_RI(vterm_t *vterm)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
 
     // set vterm desc buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     // check to see if we're at the top already
     if(v_desc->crow <= v_desc->scroll_min)

--- a/vterm_misc.c
+++ b/vterm_misc.c
@@ -8,11 +8,9 @@ inline void
 clamp_cursor_to_bounds(vterm_t *vterm)
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
 
     // set vterm description buffer seletor
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     if(v_desc->crow < 0) v_desc->crow = 0;
 

--- a/vterm_private.h
+++ b/vterm_private.h
@@ -105,6 +105,15 @@ struct _vterm_s
 {
     vterm_desc_t    vterm_desc[3];              // normal buffer and alt buffer
     int             vterm_desc_idx;             // index of active buffer;
+    vterm_desc_t    *v_desc_active;             /*
+                                                    cached pointer to the
+                                                    active descriptor.  only
+                                                    written by
+                                                    vterm_buffer_set_active.
+                                                    read everywhere else
+                                                    instead of recomputing
+                                                    &vterm_desc[idx] per call.
+                                                */
 
     WINDOW          *window;                    // curses window
 

--- a/vterm_render.c
+++ b/vterm_render.c
@@ -163,11 +163,9 @@ vterm_put_char(vterm_t *vterm, chtype c, wchar_t *wch)
 {
     vterm_desc_t    *v_desc = NULL;
     vterm_cell_t    *vcell = NULL;
-    int             idx;
 
     // set vterm desc buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     if(v_desc->ccol >= v_desc->cols)
     {
@@ -220,14 +218,12 @@ void
 vterm_get_size( vterm_t *vterm, int *width, int *height )
 {
     vterm_desc_t    *v_desc = NULL;
-    int             idx;
 
     if(vterm == NULL || width == NULL || height == NULL )
         return;
 
     // set vterm desc buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    v_desc = vterm->v_desc_active;
 
     *width = v_desc->cols;
     *height = v_desc->rows;

--- a/vterm_resize.c
+++ b/vterm_resize.c
@@ -33,9 +33,9 @@ vterm_resize_full(vterm_t *vterm, uint16_t width, uint16_t height,
     if(vterm == NULL) return;
     if(width == 0 || height == 0) return;
 
-    // set the vterm description buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    // active buffer descriptor (idx kept for the buffer_realloc call below)
+    idx = vterm->vterm_desc_idx;
+    v_desc = vterm->v_desc_active;
 
     delta_y = height - v_desc->rows;
     start_y = v_desc->rows;

--- a/vterm_scroll.c
+++ b/vterm_scroll.c
@@ -21,9 +21,9 @@ vterm_scroll_up(vterm_t *vterm, bool reset_colors)
     vterm_desc_t    *v_desc = NULL;
     int             idx;
 
-    // set vterm desc buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    // active buffer descriptor (idx kept for compares / shift_up,down calls)
+    idx = vterm->vterm_desc_idx;
+    v_desc = vterm->v_desc_active;
 
     /*
         on scroll up, copy a row to the history buffer, but only if the
@@ -76,9 +76,9 @@ vterm_scroll_down(vterm_t *vterm, bool reset_colors)
     vterm_desc_t    *v_desc = NULL;
     int             idx;
 
-    // set vterm desc buffer selector
-    idx = vterm_buffer_get_active(vterm);
-    v_desc = &vterm->vterm_desc[idx];
+    // active buffer descriptor (idx kept for compares / shift_up,down calls)
+    idx = vterm->vterm_desc_idx;
+    v_desc = vterm->v_desc_active;
 
     // move the cursor up
     v_desc->crow--;

--- a/vterm_wnd.c
+++ b/vterm_wnd.c
@@ -58,10 +58,13 @@ vterm_wnd_update(vterm_t *vterm, int idx, int offset, uint8_t flags)
     // set vterm desc buffer selector
     if(idx == -1)
     {
-        idx = vterm_buffer_get_active(vterm);
+        idx = vterm->vterm_desc_idx;
+        v_desc = vterm->v_desc_active;
     }
-
-    v_desc = &vterm->vterm_desc[idx];
+    else
+    {
+        v_desc = &vterm->vterm_desc[idx];
+    }
 
     getmaxyx(vterm->window, height, width);
     VAR_UNUSED(width);


### PR DESCRIPTION
Add v_desc_active to vterm_t and maintain it from vterm_buffer_set_active. Hot-path callers now read the cached pointer instead of recomputing &vterm_desc[idx] via vterm_buffer_get_active() on every call.

vterm_buffer_get_active() is preserved for ABI.