### PR TITLE
add plain-ASCII fast path to vterm_render

### DIFF
--- a/vterm_render.c
+++ b/vterm_render.c
@@ -41,6 +41,33 @@ vterm_render(vterm_t *vterm, char *data, int len)
 
     for(i = 0; i < len; i++, data++)
     {
+        /*
+            plain-ASCII fast path.  most terminal output is long runs of
+            printable ASCII (shell prompts, log lines, source code, build
+            output).  when no escape sequence, no UTF-8 assembly, and no
+            rxvt RS1 scanner is active, drop straight into a tight loop
+            that calls vterm_put_char and bypasses the per-byte C0/C1/
+            UTF-8/escape branch barrage.
+
+            rxvt mode keeps a stateful scanner in rs1_reset that must see
+            every byte to track partial matches of RXVT_RS1, so we sit
+            out the fast path when it is installed.
+        */
+        if(vterm->rs1_reset == NULL
+            && !IS_MODE_ESCAPED(vterm)
+            && !IS_MODE_UTF8(vterm))
+        {
+            while(i < len
+                && (unsigned char)*data >= 0x20
+                && (unsigned char)*data <= 0x7E)
+            {
+                vterm_put_char(vterm, (unsigned char)*data, NULL);
+                i++;
+                data++;
+            }
+            if(i >= len) break;
+        }
+
         // completely ignore NUL
         if(*data == 0) continue;
 


### PR DESCRIPTION
Long runs of printable ASCII (0x20-0x7E) are the dominant input class on a terminal.  Each byte still paid the full C0/C1/UTF-8/escape branch barrage plus an indirect rs1_reset check.  Gate on rs1_reset==NULL, !escaped, !utf8 and drop into a tight inner loop that calls vterm_put_char directly until a byte outside the printable ASCII range arrives.  Rxvt mode sits out the fast path so its stateful RS1 scanner keeps seeing every byte.