### PR TITLE
fix off-by-one in vterm_buffer_realloc width-grow

### DIFF
--- a/vterm_buffer.c
+++ b/vterm_buffer.c
@@ -106,7 +106,7 @@ vterm_buffer_realloc(vterm_t *vterm, int idx, int width, int height)
             sizeof(vterm_cell_t) * new_width);
 
         // fill new cols with blanks
-        start_x = max_cols_old - 1;
+        start_x = max_cols_old;
         for(c = start_x; c < new_width; c++)
         {
             VCELL_ZERO_ALL(v_desc->cells[r][c]);


### PR DESCRIPTION
start_x = max_cols_old - 1 zeroed the last column of existing content before filling new columns, clobbering right-edge characters (e.g. mc panel borders) on every width-grow.  Also risked an OOB write at cells[r][-1] if max_cols_old were ever 0.