### PR TITLE
fold RS1 scanner into escape handler, enable fast path for rxvt

### DIFF
--- a/vterm.c
+++ b/vterm.c
@@ -155,7 +155,9 @@ vterm_init(vterm_t *vterm, uint16_t width, uint16_t height, uint32_t flags)
         others typically use \Ec
     */
     if(flags & VTERM_FLAG_RXVT)
+    {
         vterm->rs1_reset = interpret_csi_RS1_rxvt;
+    }
 
     if(flags & VTERM_FLAG_NOPTY)
     { // skip all the child process and fd stuff.

--- a/vterm_csi_RS1.c
+++ b/vterm_csi_RS1.c
@@ -8,40 +8,28 @@
 #include "vterm_buffer.h"
 
 
-/*
-    we're looking for a very specific sequence.  using a protothread here
-    would probably make sense, but it's pretty easy to do this with some
-    statics as well.
-*/
 int
 interpret_csi_RS1_rxvt(vterm_t *vterm, char *byte)
 {
-    static char     *end = RXVT_RS1 + sizeof(RXVT_RS1) - 2;
-    static char     *pos = RXVT_RS1;
+    static int      end = sizeof(RXVT_RS1) - 2;
 
-    // if we get a stray byte, reset sequence parser
-    if(byte[0] != pos[0])
+    if(byte[0] != RXVT_RS1[vterm->rs1_off])
     {
-        pos = RXVT_RS1;
+        vterm->rs1_off = 0;
         return 0;
     }
 
-    // do the bytes match and are we at the end
-    if((pos[0] == end[0] && pos == end))
+    if(vterm->rs1_off == end)
     {
-        // reset to standard buffer (and add other stuff if ncessary)
         vterm_buffer_set_active(vterm, VTERM_BUF_STANDARD);
-
-        // make cursor always visible after a reset
         vterm_cursor_show(vterm, VTERM_BUF_STANDARD);
 
-        // reset the parser
-        pos = RXVT_RS1;
+        vterm->rs1_off = 0;
 
         return 0;
     }
 
-    pos++;
+    vterm->rs1_off++;
 
     return 0;
 }

--- a/vterm_private.h
+++ b/vterm_private.h
@@ -209,6 +209,7 @@ struct _vterm_s
     int             (*write)            (vterm_t *, uint32_t);
     int             (*esc_handler)      (vterm_t *);
     int             (*rs1_reset)        (vterm_t *, char *);
+    int             rs1_off;            //  scanner offset within RXVT_RS1
     ssize_t         (*mouse_driver)     (vterm_t *, unsigned char *);
 
     // callbacks that the implementer can specify

--- a/vterm_render.c
+++ b/vterm_render.c
@@ -45,17 +45,13 @@ vterm_render(vterm_t *vterm, char *data, int len)
             plain-ASCII fast path.  most terminal output is long runs of
             printable ASCII (shell prompts, log lines, source code, build
             output).  when no escape sequence, no UTF-8 assembly, and no
-            rxvt RS1 scanner is active, drop straight into a tight loop
+            rxvt RS1 scanner is mid-match, drop straight into a tight loop
             that calls vterm_put_char and bypasses the per-byte C0/C1/
             UTF-8/escape branch barrage.
-
-            rxvt mode keeps a stateful scanner in rs1_reset that must see
-            every byte to track partial matches of RXVT_RS1, so we sit
-            out the fast path when it is installed.
         */
-        if(vterm->rs1_reset == NULL
-            && !IS_MODE_ESCAPED(vterm)
-            && !IS_MODE_UTF8(vterm))
+        if(!IS_MODE_ESCAPED(vterm)
+            && !IS_MODE_UTF8(vterm)
+            && vterm->rs1_off == 0)
         {
             while(i < len
                 && (unsigned char)*data >= 0x20
@@ -71,8 +67,12 @@ vterm_render(vterm_t *vterm, char *data, int len)
         // completely ignore NUL
         if(*data == 0) continue;
 
-        // special processing looking for reset sequence
-        if(vterm->rs1_reset != NULL) vterm->rs1_reset(vterm, (char *)data);
+        // only invoke the RS1 scanner on ESC or when mid-match
+        if(vterm->rs1_reset != NULL
+            && (vterm->rs1_off != 0 || *data == '\033'))
+        {
+            vterm->rs1_reset(vterm, (char *)data);
+        }
 
 
         if(!IS_MODE_ESCAPED(vterm))


### PR DESCRIPTION
the per-byte rs1_reset call fired on every input byte in rxvt mode just to scan for a rare reset sequence, and it blocked the ASCII fast path entirely.  move scanner state from static vars into vterm_t (rs1_off) so it is per-instance, and only invoke the scanner on ESC or when mid-match.  the ASCII fast path now engages in rxvt mode when the scanner is idle.