### PR TITLE
dispatch escape type once on first byte, suffix-check thereafter

### DIFF
--- a/vterm_escape.c
+++ b/vterm_escape.c
@@ -30,6 +30,49 @@ vterm_interpret_esc_scs(vterm_t *vterm);
 static int
 vterm_interpret_dec_private(vterm_t *vterm);
 
+static bool
+check_suffix_csi(vterm_t *vterm)
+{
+    return validate_csi_escape_suffix(&vterm->esbuf[vterm->esbuf_len - 1]);
+}
+
+static bool
+check_suffix_osc(vterm_t *vterm)
+{
+    char *lastchar = &vterm->esbuf[vterm->esbuf_len - 1];
+
+    if(vterm->flags & VTERM_FLAG_LINUX)
+    {
+        if(*lastchar == 'R' && *(lastchar - 1) == ']')
+        {
+            vterm_escape_cancel(vterm);
+            return false;
+        }
+    }
+
+    return validate_xterm_escape_suffix(lastchar);
+}
+
+static bool
+check_suffix_scs(vterm_t *vterm)
+{
+    return validate_scs_escape_suffix(&vterm->esbuf[vterm->esbuf_len - 1]);
+}
+
+static bool
+check_suffix_dcs(vterm_t *vterm)
+{
+    return (vterm->esbuf_len > 2
+        && vterm->esbuf[vterm->esbuf_len - 2] == '\x1B'
+        && vterm->esbuf[vterm->esbuf_len - 1] == '\\');
+}
+
+static bool
+check_suffix_dec(vterm_t *vterm)
+{
+    return validate_dec_private_suffix(&vterm->esbuf[vterm->esbuf_len - 1]);
+}
+
 void
 vterm_escape_start(vterm_t *vterm)
 {
@@ -40,6 +83,7 @@ vterm_escape_start(vterm_t *vterm)
     vterm->esbuf[0] = '\0';
 
     vterm->esc_handler = NULL;
+    vterm->esc_suffix_check = NULL;
 
     return;
 }
@@ -57,6 +101,7 @@ vterm_escape_cancel(vterm_t *vterm)
     vterm->esbuf[0] = '\0';
 
     vterm->esc_handler = NULL;
+    vterm->esc_suffix_check = NULL;
 
     return;
 }
@@ -65,7 +110,6 @@ void
 vterm_interpret_escapes(vterm_t *vterm)
 {
     char                firstchar;
-    char                *lastchar;
 
     static void         *interim_table[] =
                             {
@@ -86,110 +130,49 @@ vterm_interpret_escapes(vterm_t *vterm)
 
 
     firstchar = vterm->esbuf[0];
-    lastchar = &vterm->esbuf[vterm->esbuf_len - 1];
 
     // too early to do anything
     if(!firstchar) return;
-
-    /*
-        this should never happen yet it does (cacaxine).  in this situation
-        we'll just deactivate the escape parser.
-    */
-    if(vterm->esbuf_len > 1 && *lastchar == '\033')
-    {
-        if(!(vterm->internal_state & STATE_OSC_MODE))
-        {
-            vterm_escape_cancel(vterm);
-            return;
-        }
-    }
 
     retval = vterm_interpret_escapes_simple(vterm, firstchar);
     if(retval > 0) return;
 
     SWITCH(interim_table, (unsigned char)firstchar, 0);
 
-    // looks like an complete xterm Operating System Command
     interim_OSC:
-
         vterm->internal_state |= STATE_OSC_MODE;
+        vterm->esc_handler = vterm_interpret_xterm_osc;
+        vterm->esc_suffix_check = check_suffix_osc;
+        return;
 
-        // term type linux sends this to reset FG and BG colors to default
-        if(vterm->flags & VTERM_FLAG_LINUX)
-        {
-            if(*lastchar == 'R' && *(lastchar - sizeof(char)) == ']')
-            {
-               vterm_escape_cancel(vterm);
-               goto interim_run;
-            }
-        }
-
-        if(validate_xterm_escape_suffix(lastchar))
-        {
-            vterm->esc_handler = vterm_interpret_xterm_osc;
-        }
-        goto interim_run;
-
-    // we have a complete csi escape sequence: interpret it
     interim_CSI:
+        vterm->esc_handler = vterm_interpret_csi;
+        vterm->esc_suffix_check = check_suffix_csi;
+        return;
 
-        if(validate_csi_escape_suffix(lastchar))
-        {
-            vterm->esc_handler = vterm_interpret_csi;
-        }
-        goto interim_run;
-
-    // SCS G0 sequence - discards for now
     interim_lparth:
-        if(validate_scs_escape_suffix(lastchar))
-        {
-            vterm->esc_handler = vterm_interpret_esc_scs;
-        }
-        goto interim_run;
+        vterm->esc_handler = vterm_interpret_esc_scs;
+        vterm->esc_suffix_check = check_suffix_scs;
+        return;
 
-    // SCS G1 sequence - discards for now
     interim_rparth:
-        if(validate_scs_escape_suffix(lastchar))
-        {
-            vterm->esc_handler = vterm_interpret_esc_scs;
-        }
-        goto interim_run;
+        vterm->esc_handler = vterm_interpret_esc_scs;
+        vterm->esc_suffix_check = check_suffix_scs;
+        return;
 
-
-    // DCS sequence - starts in P and ends in Esc backslash
     interim_char_P:
-        if( vterm->esbuf_len > 2
-            && vterm->esbuf[vterm->esbuf_len - 2] == '\x1B'
-            && *lastchar == '\\' )
-        {
-            vterm->esc_handler = vterm_interpret_esc_xterm_dsc;
-        }
-        goto interim_run;
+        vterm->esc_handler = vterm_interpret_esc_xterm_dsc;
+        vterm->esc_suffix_check = check_suffix_dcs;
+        return;
 
-    // some DEC private modes start with a # (pound) sign
     interim_pound:
-        if(validate_dec_private_suffix(lastchar))
-        {
-            vterm->esc_handler = vterm_interpret_dec_private;
-        }
-        goto interim_run;
+        vterm->esc_handler = vterm_interpret_dec_private;
+        vterm->esc_suffix_check = check_suffix_dec;
+        return;
 
     interim_char_none:
         vterm_escape_cancel(vterm);
         return;
-
-    interim_run:
-
-    // if an escape handler has been configured, run it.
-    if(vterm->esc_handler != NULL)
-    {
-        vterm->esc_handler(vterm);
-        vterm_escape_cancel(vterm);
-
-        return;
-    }
-
-    return;
 }
 
 int

--- a/vterm_private.h
+++ b/vterm_private.h
@@ -208,6 +208,7 @@ struct _vterm_s
     // internal callbacks
     int             (*write)            (vterm_t *, uint32_t);
     int             (*esc_handler)      (vterm_t *);
+    bool            (*esc_suffix_check) (vterm_t *);
     int             (*rs1_reset)        (vterm_t *, char *);
     int             rs1_off;            //  scanner offset within RXVT_RS1
     ssize_t         (*mouse_driver)     (vterm_t *, unsigned char *);

--- a/vterm_render.c
+++ b/vterm_render.c
@@ -162,8 +162,25 @@ vterm_render(vterm_t *vterm, char *data, int len)
                 vterm->esbuf_len++;
                 vterm->esbuf[vterm->esbuf_len] = 0;
 
-                // if we are in escape mode (initiated by 0x1B) go here...
-                vterm_interpret_escapes(vterm);
+                if(vterm->esc_suffix_check != NULL)
+                {
+                    // stray ESC inside a non-OSC sequence kills the parse
+                    if(*data == '\033' && !IS_OSC_MODE(vterm))
+                    {
+                        vterm_escape_cancel(vterm);
+                        continue;
+                    }
+
+                    if(vterm->esc_suffix_check(vterm))
+                    {
+                        vterm->esc_handler(vterm);
+                        vterm_escape_cancel(vterm);
+                    }
+                }
+                else
+                {
+                    vterm_interpret_escapes(vterm);
+                }
                 continue;
             }
         }


### PR DESCRIPTION
vterm_interpret_escapes re-ran the jump table on every appended byte, redundantly re-deriving the sequence type for each byte of a multi-byte escape — O(n^2) dispatches for an n-byte sequence.

Now the jump table fires only on the first byte, stashing both the handler and a per-type suffix checker.  Subsequent bytes call the suffix checker directly from vterm_render, bypassing the full dispatch. The jump table and its label structure are untouched.