### PR TITLE
add DSR/CPR response (CSI 5n / 6n) -- fixes glow --tui blank screen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ add_library(vterm-static STATIC
     vterm_csi_RS1.c
     vterm_csi_SAVECUR.c
     vterm_csi_SD.c
+    vterm_csi_DSR.c
     vterm_csi_SGR.c
     vterm_csi_SU.c
     vterm_csi_UNKNOWN.c
@@ -174,6 +175,7 @@ add_library(vterm.o OBJECT
     vterm_csi_RS1.c
     vterm_csi_SAVECUR.c
     vterm_csi_SD.c
+    vterm_csi_DSR.c
     vterm_csi_SGR.c
     vterm_csi_SU.c
     vterm_csi_UNKNOWN.c

--- a/vterm_csi.c
+++ b/vterm_csi.c
@@ -54,6 +54,7 @@ vterm_interpret_csi(vterm_t *vterm)
                         ['Z'] = &&csi_char_Z,
                         ['S'] = &&csi_SU,
                         ['p'] = &&csi_char_p,
+                        ['n'] = &&csi_DSR,
                     };
 
     p = vterm->esbuf + 1;
@@ -219,6 +220,13 @@ vterm_interpret_csi(vterm_t *vterm)
     csi_SU:
         // interpret_csi_SD(vterm, csiparam, param_count);
         interpret_csi_SU(vterm, csiparam, param_count);
+        return 0;
+
+    csi_DSR:
+        // device status / cursor position report; standard (non-DEC) form
+        // only -- DEC's CSI ? 6 n (DECXCPR) is left for the unknown trap
+        if(dec_sequence == FALSE)
+            interpret_csi_DSR(vterm, csiparam, param_count);
         return 0;
 
     csi_EWMH:

--- a/vterm_csi.h
+++ b/vterm_csi.h
@@ -45,6 +45,7 @@ void    interpret_csi_RESTORECUR(vterm_t *vterm, int param[], int pcount);
 void    interpret_csi_CBT(vterm_t *vterm, int param[], int pcount);
 void    interpret_csi_SU(vterm_t *vterm, int param[], int pcount);
 void    interpret_csi_SD(vterm_t *vterm, int param[], int pcount);
+void    interpret_csi_DSR(vterm_t *vterm, int param[], int pcount);
 
 int     interpret_csi_RS1_rxvt(vterm_t *vterm, char *data);
 int     interpret_csi_RS1_xterm(vterm_t *vterm, char *data);

--- a/vterm_csi_DSR.c
+++ b/vterm_csi_DSR.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "vterm.h"
+#include "vterm_private.h"
+#include "vterm_csi.h"
+#include "vterm_reply.h"
+
+/*
+    Interpret a Device Status Report (DSR) request and reply on the pty:
+
+        CSI 5 n  ->  "\033[0n"            device OK
+        CSI 6 n  ->  "\033[<row>;<col>R"  Cursor Position Report (1-based)
+
+    Apps built on termenv / Charm (e.g. glow --tui) pair every OSC color
+    query with a CSI 6 n and read until the CPR reply arrives -- the CPR is
+    their terminator.  Without it they stall during capability detection
+    and never enter the TUI.  Only the standard (non-DEC) form is answered;
+    the DEC variant (CSI ? 6 n, DECXCPR) is intentionally left alone.
+*/
+void
+interpret_csi_DSR(vterm_t *vterm, int param[], int pcount)
+{
+    vterm_desc_t    *v_desc;
+    int             verb;
+
+    verb = (pcount == 0) ? 0 : param[0];
+
+    if(verb == 6)
+    {
+        // CPR -- report the active buffer's cursor, converted to 1-based
+        v_desc = vterm->v_desc_active;
+
+        memset(vterm->reply_buf, 0, sizeof(vterm->reply_buf));
+        vterm->reply_buf_sz = snprintf(vterm->reply_buf,
+            sizeof(vterm->reply_buf), "\033[%d;%dR",
+            v_desc->crow + 1, v_desc->ccol + 1);
+
+        vterm_reply_buffer(vterm);
+    }
+    else if(verb == 5)
+    {
+        // device status -- always report OK
+        memset(vterm->reply_buf, 0, sizeof(vterm->reply_buf));
+        vterm->reply_buf_sz = snprintf(vterm->reply_buf,
+            sizeof(vterm->reply_buf), "\033[0n");
+
+        vterm_reply_buffer(vterm);
+    }
+
+    return;
+}


### PR DESCRIPTION
termenv / Charm apps (glow --tui) pair every OSC color query with a CSI 6 n and read until the Cursor Position Report arrives -- the CPR is their terminator.  libvterm had no 'n' handler at all, so the probe never completed: glow aborted during capability detection and never entered the TUI (confirmed via --dump -- the child went silent right after three "OSC 10/11 ; ? ST  +  ESC[6n" probes).

New vterm_csi_DSR replies through the reply_buf / vterm_reply_buffer path the DA handler already uses:
  CSI 6 n -> ESC[<row>;<col>R   cursor position (1-based, from v_desc_active)
  CSI 5 n -> ESC[0n             device status OK
Standard (non-DEC) form only; the DEC variant (CSI ? 6 n, DECXCPR) is left
to the unknown trap.  Wired into the CSI dispatch table, vterm_csi.h, and
both CMakeLists source lists.