### PR TITLE
mouse: fix SGR wheel button codes (68/69 -> 64/65) so scroll works

### DIFF
--- a/mouse_driver_SGR.c
+++ b/mouse_driver_SGR.c
@@ -67,7 +67,8 @@ mouse_driver_SGR(vterm_t *vterm, unsigned char *buf)
         if(vterm->mouse_mode & VTERM_MOUSE_ALTSCROLL)
             sprintf((char *)buf, "\033OA");
         else
-            sprintf((char *)buf, "\033[<%d;%d;%dM", button + 64 + 4, x, y);
+            // SGR wheel-up is button 64 (+ modifier bits)
+            sprintf((char *)buf, "\033[<%d;%d;%dM", button + 64, x, y);
 
         retval = strlen((char *)buf);
 
@@ -79,7 +80,8 @@ mouse_driver_SGR(vterm_t *vterm, unsigned char *buf)
         if(vterm->mouse_mode & VTERM_MOUSE_ALTSCROLL)
             sprintf((char *)buf, "\033OB");
         else
-            sprintf((char *)buf, "\033[<%d;%d;%dM", button + 64 + 5, x, y);
+            // SGR wheel-down is button 65 (+ modifier bits)
+            sprintf((char *)buf, "\033[<%d;%d;%dM", button + 65, x, y);
 
         retval = strlen((char *)buf);
 


### PR DESCRIPTION
The SGR mouse encoder emitted wheel-up/down as button + 64 + 4 and button + 64 + 5 (i.e. 68 / 69), but the SGR wheel button codes are 64 (up) and 65 (down).  Apps that scroll via SGR mouse -- e.g. glow --tui with --mouse -- received unrecognized button codes and didn't scroll. Emit 64 / 65 (plus the existing modifier bits).

Coordinate handling is left as-is: wmouse_trafo() correctly maps the host-pushed event onto the terminal window (it accounts for the window's title/border offset); an earlier attempt to bypass it for injected events shifted clicks by the border height in mc / htop and was dropped.