### PR TITLE
scroll: clear alt-screen recycled rows with current bg, not stale colors

### DIFF
--- a/vterm_buffer.h
+++ b/vterm_buffer.h
@@ -41,9 +41,10 @@ struct _vterm_desc_s;
     with a template cell and mark the span dirty in one pass.  the
     erase-family handlers all funnel here; flavor (which attr, which
     colors) is the caller's explicit choice.  colors == -1 preserves
-    each cell's existing colors (the erase_row(reset_colors == FALSE)
-    flavor used by alt-screen scrolling) while wch and attr are still
-    overwritten.
+    each cell's existing colors while wch and attr are still
+    overwritten (no caller currently uses this flavor: erase_row now
+    passes a real pair for both reset_colors flavors so a recycled
+    row never inherits a prior occupant's background).
 */
 void    vterm_fill_span(struct _vterm_desc_s *v_desc, int row,
             int col_start, int col_end, wchar_t ch, attr_t attr,

--- a/vterm_erase.c
+++ b/vterm_erase.c
@@ -58,10 +58,19 @@ vterm_erase_row(vterm_t *vterm, int row, bool reset_colors, char fill_char)
 
     if(row == -1) row = v_desc->crow;
 
-    // colors == -1 preserves each cell's existing colors
+    /*
+        reset_colors TRUE  -> blank with the default pair (NEL / RI).
+        reset_colors FALSE -> blank with the CURRENT pair (BCE), matching
+        EL/ED/ECH/SU/SD/IL/DL and xterm.  This path clears the row a
+        newline-scroll just recycled; using -1 (preserve each cell's old
+        colors) left the stale background of whatever previously occupied
+        that row -- e.g. an inline-code span's gray bg -- and apps that
+        rely on the scrolled-in line being clean (glow, which emits no
+        \e[K after redrawing) showed it bleeding down the screen.
+    */
     vterm_fill_span(v_desc, row, 0, v_desc->cols - 1,
         (wchar_t)fill_char, A_NORMAL,
-        reset_colors == TRUE ? v_desc->default_colors : -1);
+        reset_colors == TRUE ? v_desc->default_colors : v_desc->colors);
 
     return;
 }


### PR DESCRIPTION
On the alternate screen, a newline that scrolls the region runs vterm_scroll_up(FALSE) (vterm_ctrl_char.c's NL handler picks FALSE for the alt buffer).  That bottomed out in vterm_erase_row(reset_colors == FALSE) -> vterm_fill_span(colors == -1), whose "-1" flavor blanks the glyph but PRESERVES each cell's existing color pair.  After the shift, the recycled bottom row still physically holds the prior occupant's cells, so preserving their colors left a stale background behind -- e.g. the gray bg of an inline-code span -- on the row just below where that span scrolled to.  Apps that assume a scrolled-in line is clean and emit no \e[K when redrawing (glow --tui) showed it as a colored band bleeding down the screen.

Fill the recycled row with the CURRENT pair (v_desc->colors, i.e. BCE) instead, matching what EL/ED/ECH/SU/SD/IL/DL already do and what xterm does.  At a normal scroll the current pair is the default (apps reset before scrolling), so the line comes out clean; an app scrolling with a non-default bg gets that bg, as xterm would.  The standard buffer's TRUE/default-pair path is unchanged.

Verified by replaying glow's captured byte stream through libvterm (no-pty): the bleed band (rows 29-33, ~141 stale-colored blank cells) is gone, legitimate colors untouched; a minimal alt-screen repro drops from 15 stray cells to 0.