### PR TITLE
render: don't decode UTF-8 inside an escape/OSC sequence

### DIFF
--- a/vterm_render.c
+++ b/vterm_render.c
@@ -96,7 +96,15 @@ vterm_render(vterm_t *vterm, char *data, int len)
         }
 
 #ifndef NOUTF8
-        if(!(vterm->flags & VTERM_FLAG_NOUTF8))
+        /*
+            assemble UTF-8 only when NOT inside an escape/OSC sequence.  an
+            OSC string (e.g. an xterm window title) can legitimately carry
+            UTF-8; those bytes must accumulate into esbuf and be consumed by
+            the OSC handler below -- not get decoded and PRINTED at the
+            cursor.  this leak put an app's UTF-8 title-spinner glyphs on
+            screen at the cursor position.
+        */
+        if(!(vterm->flags & VTERM_FLAG_NOUTF8) && !IS_MODE_ESCAPED(vterm))
         {
             // UTF-8 encoding is indicated by a bit at 0x80
             if((unsigned int)*data > 0x7F && !IS_MODE_UTF8(vterm)


### PR DESCRIPTION
An OSC string (e.g. an xterm window title) can legitimately carry UTF-8. The render loop assembled UTF-8 whenever a byte was > 0x7F without checking escape/OSC mode, so a UTF-8 glyph inside an OSC -- e.g. an app's braille title-spinner -- was decoded and PRINTED at the cursor instead of being consumed by the OSC handler.  Guard UTF-8 assembly with !IS_MODE_ESCAPED so those bytes accumulate into esbuf like the ASCII ones do.