### PR TITLE
Add vterm_wnd_scrollback() for sub-screen scrollback

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+10.4
+
+Scrollback API
+* [Bryan Christ] Add vterm_wnd_scrollback() -- render a scrollback view that
+  composes the newest N evicted history rows above the head of the live
+  standard screen, the way a hardware terminal scrolls back.  Unlike
+  vterm_wnd_update(VTERM_BUF_HISTORY), which can only show whole screens of
+  evicted rows, this reveals fewer-than-one-screen of history against the
+  live buffer.  Additive and ABI-compatible.
+
 10.3
 
 Scrollback API

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.10.2)
 
 project(libvterm C)
 set(MAJOR_VERSION 10)
-set(MINOR_VERSION 3)
+set(MINOR_VERSION 4)
 
 message("CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 

--- a/vterm.h
+++ b/vterm.h
@@ -28,7 +28,7 @@
 #undef FALSE
 #define FALSE           0
 
-#define LIBVTERM_VERSION        "10.3"
+#define LIBVTERM_VERSION        "10.4"
 
 #define VTERM_FLAG_RXVT         (1UL << 0)      //  emulate rxvt
 #define VTERM_FLAG_VT100        (1UL << 1)      //  emulate vt100
@@ -517,6 +517,23 @@ void            vterm_wnd_size(vterm_t *vterm, int *width, int *height);
 */
 int             vterm_wnd_update(vterm_t *vterm, int idx, int offset,
                         uint8_t flags);
+
+/*
+    Render a scrollback view into the attached window: the newest `nlines`
+    evicted history rows composed above the head of the live standard screen,
+    the way a hardware terminal scrolls back.  nlines == 0 renders the live
+    screen; each additional line slides one evicted row in at the top and
+    pushes the live screen down one row.  Unlike vterm_wnd_update() with
+    VTERM_BUF_HISTORY -- which can only show whole screens of evicted rows --
+    this reveals fewer-than-one-screen of history against the live buffer.
+
+    @param vterm:       the vterm instance.
+    @param nlines:      scroll-back distance in rows; clamp to
+                        0 .. vterm_get_history_used().
+    @param flags:       reserved (the whole window is repainted).
+    @return:            0 on success, -1 on error.
+*/
+int             vterm_wnd_scrollback(vterm_t *vterm, int nlines, uint8_t flags);
 #endif
 
 /*

--- a/vterm_wnd.c
+++ b/vterm_wnd.c
@@ -152,5 +152,100 @@ vterm_wnd_update(vterm_t *vterm, int idx, int offset, uint8_t flags)
     return -1;
 }
 
+/*
+    Render a scrollback view that composes the newest `nlines` evicted history
+    rows above the head of the live standard screen -- the way a hardware
+    terminal scrolls back.  At nlines == 0 the window is exactly the live
+    screen; each extra line slides one evicted row in at the top and pushes
+    the live screen down by one.  This reveals fewer-than-one-screen of
+    history against the live buffer, which vterm_wnd_update(VTERM_BUF_HISTORY)
+    cannot -- HISTORY holds only evicted rows, never the live screen.
+
+    `nlines` is the scroll-back distance; the caller clamps it to
+    0 .. vterm_get_history_used().  No cursor is drawn (a frozen view).
+*/
+int
+vterm_wnd_scrollback(vterm_t *vterm, int nlines, uint8_t flags)
+{
+    vterm_cell_t    *vcell;
+    vterm_desc_t    *hist;
+    vterm_desc_t    *live;
+    vterm_desc_t    *v_desc;
+    int             width, height;
+    int             capacity;
+    int             r, c, lrow, prow;
+    attr_t          attrs;
+    short           colors;
+    cchar_t         uch;
+
+    if(vterm == NULL) return -1;
+    if(vterm->window == NULL) return -1;
+
+    hist = &vterm->vterm_desc[VTERM_BUF_HISTORY];
+    live = &vterm->vterm_desc[VTERM_BUF_STANDARD];
+    capacity = hist->rows;
+
+    if(nlines < 0) nlines = 0;
+
+    getmaxyx(vterm->window, height, width);
+    VAR_UNUSED(width);
+    VAR_UNUSED(flags);
+
+    height = USE_MIN(height, live->rows);
+
+    for(r = 0; r < height; r++)
+    {
+        int skip_next = 0;
+
+        /*
+            top `lines` rows come from the tail of the history ring (newest
+            evicted first); the rest is the live screen shifted down by
+            `lines`.  history rows are right-aligned in the ring, so the
+            newest evicted row is at capacity-1.
+        */
+        if(r < nlines)
+        {
+            v_desc = hist;
+            lrow = capacity - nlines + r;
+        }
+        else
+        {
+            v_desc = live;
+            lrow = r - nlines;
+        }
+
+        if(lrow < 0 || lrow >= v_desc->rows) continue;
+        prow = vterm_desc_row_phys(v_desc, lrow);
+
+        for(c = 0; c < v_desc->cols; c++)
+        {
+            if(skip_next)
+            {
+                skip_next = 0;
+                continue;
+            }
+
+            vcell = &v_desc->cells[prow][c];
+
+            if(vcell->wch[0] > 0x7F && wcwidth(vcell->wch[0]) == 2)
+                skip_next = 1;
+
+            VCELL_GET_COLORS((*vcell), &colors);
+            VCELL_GET_ATTR((*vcell), &attrs);
+
+            if(setcchar(&uch, vcell->wch, attrs, colors, NULL) == ERR)
+            {
+                wchar_t blank[2] = { L' ', L'\0' };
+                setcchar(&uch, blank, attrs, colors, NULL);
+            }
+
+            wattr_set(vterm->window, attrs, colors, NULL);
+            mvwadd_wch(vterm->window, r, c, &uch);
+        }
+    }
+
+    return 0;
+}
+
 #endif
 


### PR DESCRIPTION
vterm_wnd_update(VTERM_BUF_HISTORY, ...) can only show whole screens of evicted rows, because HISTORY holds only evicted lines -- never the live screen.  A consumer scrolling back through less than one screenful of history therefore had nothing to render.

vterm_wnd_scrollback() composes the newest N evicted rows above the head of the live standard screen, the way a hardware terminal scrolls back: N == 0 is the live screen, and each additional line slides one evicted row in at the top.

Additive and ABI-compatible; bump to 10.4.