### PR TITLE
release: libvterm 10.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,16 @@
+10.5
+
+Interpreter bounds fixes (heap corruption from untrusted child output)
+* [Bryan Christ] DCH (CSI P) now clamps the delete count to the cells from the
+  cursor to the right margin.  An unclamped count > (cols - ccol) drove a
+  negative-index write in the blank-fill loop -- e.g. CSI 999 P on an 80-column
+  screen wrote hundreds of cells before the row buffer.
+* [Bryan Christ] The wnd_update cursor highlight now clamps to the last real
+  column at DEC pending-wrap (ccol == cols).  VCELL_DIRTY_SET(crow, cols)
+  indexed one byte past the row's dirty bitmap for widths that are a multiple
+  of 8 (the common 80-column case) -- a heap write off the end of the dirty
+  block on the bottom row.  The callerless vterm_erase_col got the same guard.
+
 10.4
 
 Scrollback API

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.10.2)
 
 project(libvterm C)
 set(MAJOR_VERSION 10)
-set(MINOR_VERSION 4)
+set(MINOR_VERSION 5)
 
 message("CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 

--- a/vterm.h
+++ b/vterm.h
@@ -28,7 +28,7 @@
 #undef FALSE
 #define FALSE           0
 
-#define LIBVTERM_VERSION        "10.4"
+#define LIBVTERM_VERSION        "10.5"
 
 #define VTERM_FLAG_RXVT         (1UL << 0)      //  emulate rxvt
 #define VTERM_FLAG_VT100        (1UL << 1)      //  emulate vt100

--- a/vterm_csi_DCH.c
+++ b/vterm_csi_DCH.c
@@ -21,6 +21,16 @@ interpret_csi_DCH(vterm_t *vterm, int param[], int pcount)
     // select the correct desc
     v_desc = vterm->v_desc_active;
 
+    /*
+        clamp the delete count to the cells from the cursor to the right
+        margin.  Without this, CSI <n> P with n > (cols - ccol) drives
+        `stride` negative and the blank-fill loop below writes
+        cells[crow][cols - n + c] at negative indices -- a heap write before
+        the row buffer for n > cols (e.g. ESC[999P on an 80-column screen).
+    */
+    if(n > v_desc->cols - v_desc->ccol)
+        n = v_desc->cols - v_desc->ccol;
+
     stride = v_desc->cols - v_desc->ccol;
     stride -= n;
 

--- a/vterm_erase.c
+++ b/vterm_erase.c
@@ -112,6 +112,11 @@ vterm_erase_col(vterm_t *vterm, int col, char fill_char)
 
     if(col == -1) col = v_desc->ccol;
 
+    /* same pending-wrap guard as the cursor draw in vterm_wnd.c: ccol can
+       rest at cols, and an out-of-range col would store past each row */
+    if(col >= v_desc->cols) col = v_desc->cols - 1;
+    if(col < 0) col = 0;
+
     // a vertical 1-wide span: one whole-cell store per row
     for(r = 0; r < v_desc->rows; r++)
     {

--- a/vterm_wnd.c
+++ b/vterm_wnd.c
@@ -142,10 +142,24 @@ vterm_wnd_update(vterm_t *vterm, int idx, int offset, uint8_t flags)
     {
         if(!(v_desc->buffer_state & STATE_CURSOR_INVIS))
         {
-            mvwchgat(vterm->window, v_desc->crow, v_desc->ccol, 1, A_REVERSE,
+            /*
+                at DEC pending-wrap the cursor rests at ccol == cols (a
+                last-column glyph advances ccol past the margin and the wrap
+                is deferred to the next glyph).  Draw + dirty the last real
+                column instead: VCELL_DIRTY_SET(crow, cols) would index
+                dirty_bits[crow][cols>>3], one byte past the row's
+                VCELL_DIRTY_ROW_BYTES(cols) when cols is a multiple of 8 (the
+                common 80-column case) -- a heap write off the end of the
+                dirty block on the bottom row.
+            */
+            int cur_col = v_desc->ccol;
+            if(cur_col >= v_desc->cols) cur_col = v_desc->cols - 1;
+            if(cur_col < 0) cur_col = 0;
+
+            mvwchgat(vterm->window, v_desc->crow, cur_col, 1, A_REVERSE,
                 v_desc->default_colors, NULL);
 
-            VCELL_DIRTY_SET(v_desc, v_desc->crow, v_desc->ccol);
+            VCELL_DIRTY_SET(v_desc, v_desc->crow, cur_col);
         }
     }
 


### PR DESCRIPTION
Two out-of-bounds writes in the interpreter, reachable from ordinary child output (2026-07-02 review items 38, 39; both verified against source).

* DCH (CSI P): the delete count from param[0] was unclamped, so n > (cols - ccol) drove the blank-fill loop to write cells[crow][cols - n + c] at negative indices -- CSI 999 P on an 80-column screen indexes to -919, a heap write before the row buffer.  Clamp n to cols - ccol.

* wnd_update cursor highlight: at DEC pending-wrap ccol == cols, and VCELL_DIRTY_SET(crow, cols) indexes dirty_bits[crow][cols>>3] -- one byte past the VCELL_DIRTY_ROW_BYTES(cols)-sized row when cols is a multiple of 8 (the common 80-column case), off the end of the contiguous dirty block on the bottom row.  Clamp the cursor column to cols-1 for the draw + dirty-set; same guard added to the callerless vterm_erase_col.