### PR TITLE
release: libvterm 10.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,15 @@
+10.6
+
+Interpreter cursor / erase fixes
+* [Bryan Christ] Single-parameter CUP/HVP (ESC[nH -- row given, column omitted)
+  now defaults the column to 1.  param[] is the shared static csiparam[], whose
+  unparsed slots keep their previous value, so the omitted column was read as the
+  column from an earlier ESC[r;cH -- placing the cursor at a stale column.
+* [Bryan Christ] EL 1 (erase-to-cursor) now clamps its end column to the last
+  real column.  At DEC pending-wrap (ccol == cols) it asked vterm_fill_span to
+  write cells[crow][cols], one cell past the row -- a heap write off the end of
+  the cell block on the bottom row.  (Sibling of the 10.5 cursor dirty-set fix.)
+
 10.5
 
 Interpreter bounds fixes (heap corruption from untrusted child output)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.10.2)
 
 project(libvterm C)
 set(MAJOR_VERSION 10)
-set(MINOR_VERSION 5)
+set(MINOR_VERSION 6)
 
 message("CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 

--- a/vterm.h
+++ b/vterm.h
@@ -28,7 +28,7 @@
 #undef FALSE
 #define FALSE           0
 
-#define LIBVTERM_VERSION        "10.5"
+#define LIBVTERM_VERSION        "10.6"
 
 #define VTERM_FLAG_RXVT         (1UL << 0)      //  emulate rxvt
 #define VTERM_FLAG_VT100        (1UL << 1)      //  emulate vt100

--- a/vterm_csi_CUx.c
+++ b/vterm_csi_CUx.c
@@ -129,7 +129,15 @@ interpret_csi_CUx(vterm_t *vterm, char verb, int param[], int pcount)
             goto csi_DEFAULT;
         }
         v_desc->crow = param[0] - 1;
-        v_desc->ccol = param[1] - 1;
+        /*
+            a one-parameter CUP/HVP (ESC[nH -- row given, column omitted) must
+            default the column to 1.  param[] is the shared static csiparam[];
+            only the parsed slots are zeroed, so reading param[1] here with
+            pcount==1 returns the column left over from a previous multi-param
+            CSI.  Default to column 0 (1-based 1) unless a second parameter was
+            actually supplied.
+        */
+        v_desc->ccol = (pcount >= 2) ? param[1] - 1 : 0;
 
 
 // all calls above jump here

--- a/vterm_csi_EL.c
+++ b/vterm_csi_EL.c
@@ -64,6 +64,14 @@ interpret_csi_EL(vterm_t *vterm, int param[], int pcount)
         }
     }
 
+    /*
+        at DEC pending-wrap ccol == cols, so EL 1 (erase_end = ccol) would ask
+        vterm_fill_span to write cells[crow][cols] -- one cell past the row
+        (fill_span only guards col_end < col_start).  Clamp to the last real
+        column; the whole visible line is still erased.
+    */
+    if(erase_end >= v_desc->cols) erase_end = v_desc->cols - 1;
+
     vterm_fill_span(v_desc, v_desc->crow, erase_start, erase_end, L' ',
         v_desc->curattr, v_desc->colors);
 


### PR DESCRIPTION
Two interpreter cursor/erase defects (2026-07-02 review items 41, 42; both verified against source and reproduced).

* CUP/HVP (vterm_csi_CUx.c): a single-parameter ESC[nH read param[1] from the shared static csiparam[], whose slots are only zeroed up to param_count -- so an omitted column returned the column from a previous ESC[r;cH, placing the cursor at a stale column (repro: ESC[10;40H then ESC[5H -> column 40, not 1). Default the column to 0 unless a second parameter was actually supplied.

* EL 1 (vterm_csi_EL.c): erase_end = ccol, which is cols at DEC pending-wrap, and vterm_fill_span only guards col_end < col_start -- so it wrote a full cell at cells[crow][cols], one past the row (ASan: heap-buffer-overflow WRITE of 16 bytes at vterm_fill_span, off the cell block on the bottom row).  Clamp erase_end to cols-1.