### PR TITLE
feat: vterm_copy_scrollback for copying the scrolled-back view (10.7)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+10.7
+
+Scrollback-view cell copy
+* [Bryan Christ] Add vterm_copy_scrollback(vterm, nlines, &rows, &cols): the
+  copy-buffer counterpart to vterm_wnd_scrollback, composing the newest nlines
+  evicted history rows above the live screen into a freshly allocated cell
+  matrix (nlines == 0 is the live buffer, identical to vterm_copy_buffer).
+  Lets a caller copy text from a scrolled-back view, not just the live screen;
+  freed per row by the caller like vterm_copy_buffer.  Additive.
+
 10.6
 
 Interpreter cursor / erase fixes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.10.2)
 
 project(libvterm C)
 set(MAJOR_VERSION 10)
-set(MINOR_VERSION 6)
+set(MINOR_VERSION 7)
 
 message("CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 

--- a/vterm.h
+++ b/vterm.h
@@ -28,7 +28,7 @@
 #undef FALSE
 #define FALSE           0
 
-#define LIBVTERM_VERSION        "10.6"
+#define LIBVTERM_VERSION        "10.7"
 
 #define VTERM_FLAG_RXVT         (1UL << 0)      //  emulate rxvt
 #define VTERM_FLAG_VT100        (1UL << 1)      //  emulate vt100
@@ -795,6 +795,18 @@ void                vterm_get_size(vterm_t *vterm, int *width, int *height);
 
 */
 vterm_cell_t**      vterm_copy_buffer(vterm_t *vterm, int *rows, int *cols);
+
+/*
+    vterm_copy_scrollback
+
+    Like vterm_copy_buffer, but returns the SCROLLBACK view: the newest
+    `nlines` evicted history rows composed above the live screen -- the
+    copy-buffer counterpart to vterm_wnd_scrollback.  nlines == 0 yields the
+    live buffer.  The returned matrix is freed per row by the caller, exactly
+    like vterm_copy_buffer.
+*/
+vterm_cell_t**      vterm_copy_scrollback(vterm_t *vterm, int nlines,
+                        int *rows, int *cols);
 
 #endif
 

--- a/vterm_buffer.c
+++ b/vterm_buffer.c
@@ -736,6 +736,66 @@ vterm_copy_buffer(vterm_t *vterm, int *rows, int *cols)
     return buffer;
 }
 
+/*
+    Compose the scrollback view -- the newest `nlines` evicted history rows
+    above the head of the live standard screen -- into a freshly allocated cell
+    matrix: the copy-buffer counterpart to vterm_wnd_scrollback's on-screen
+    render.  At nlines == 0 this is exactly the live buffer (like
+    vterm_copy_buffer).  *rows / *cols report the matrix size; the caller frees
+    it per row, same contract as vterm_copy_buffer.  `nlines` is clamped to
+    >= 0 (the caller bounds it to vterm_get_history_used()).
+*/
+vterm_cell_t**
+vterm_copy_scrollback(vterm_t *vterm, int nlines, int *rows, int *cols)
+{
+    vterm_desc_t    *hist;
+    vterm_desc_t    *live;
+    vterm_desc_t    *v_desc;
+    vterm_cell_t    **buffer;
+    int             capacity, height, r, lrow, prow;
+
+    if(vterm == NULL) return NULL;
+    if(rows == NULL || cols == NULL) return NULL;
+
+    hist = &vterm->vterm_desc[VTERM_BUF_HISTORY];
+    live = &vterm->vterm_desc[VTERM_BUF_STANDARD];
+    capacity = hist->rows;
+
+    if(nlines < 0) nlines = 0;
+
+    height = live->rows;
+    *rows  = height;
+    *cols  = live->max_cols;
+
+    buffer = _vterm_buffer_alloc_raw(*rows, *cols);
+    if(buffer == NULL) return NULL;
+
+    /* mirror vterm_wnd_scrollback: the top `nlines` rows come from the tail of
+       the history ring (newest evicted first, right-aligned at capacity-1);
+       the rest is the live screen shifted down by `nlines`. */
+    for(r = 0; r < height; r++)
+    {
+        if(r < nlines)
+        {
+            v_desc = hist;
+            lrow   = capacity - nlines + r;
+        }
+        else
+        {
+            v_desc = live;
+            lrow   = r - nlines;
+        }
+
+        if(lrow < 0 || lrow >= v_desc->rows) continue;   /* leave row blank */
+        prow = vterm_desc_row_phys(v_desc, lrow);
+
+        memcpy(&buffer[r][0], &v_desc->cells[prow][0],
+            (size_t)v_desc->cols * sizeof(vterm_cell_t));
+    }
+
+    return buffer;
+}
+
 vterm_cell_t **
 _vterm_buffer_alloc_raw(int rows, int cols)
 {


### PR DESCRIPTION
Add vterm_copy_scrollback(vterm, nlines, &rows, &cols): the copy-buffer counterpart to vterm_wnd_scrollback. It composes the newest `nlines` evicted history rows above the live screen into a freshly allocated cell matrix (nlines == 0 is the live buffer, identical to vterm_copy_buffer), freed per row by the caller like vterm_copy_buffer. Lets a caller copy text from a scrolled-back view, not just the live screen.

Additive API; version 10.6 -> 10.7.