### PR TITLE
feat: VTERM_FLAG_START_HOME and vshell --start-home

### DIFF
--- a/demo/vshell.c
+++ b/demo/vshell.c
@@ -1280,6 +1280,13 @@ vshell_parse_cmdline(vshell_t *vshell)
                 continue;
             }
 
+            if (strncmp(vshell->argv[i], "--start-home",
+                strlen("--start-home")) == 0)
+            {
+                vshell->vterm_flags |= VTERM_FLAG_START_HOME;
+                continue;
+            }
+
 #ifndef ASYNC_NOT_OKAY
             if (strncmp(vshell->argv[i], "--async", strlen("--async")) == 0)
             {
@@ -1431,6 +1438,9 @@ vshell_print_help(void)
                 "               Lines of scrollback to keep per pane\n\r"
                 "               (clamped to 64 - 512; default is 4x the\n\r"
                 "               terminal height).\n\r"
+                "--start-home   Start the child shell (or --exec program)\n\r"
+                "               in the user home directory instead of the\n\r"
+                "               current working directory.\n\r"
                 "--exec <prg>   Launch program at start up.\n\r";
 
     printf("\n\rLibvterm version: %s\n\r\n\r%s\n\r",

--- a/vterm.h
+++ b/vterm.h
@@ -57,6 +57,17 @@
                                                     whether mouse works.)
                                                 */
 
+#define VTERM_FLAG_START_HOME   (1UL << 6)      /*
+                                                    after forkpty, chdir the
+                                                    child into the user's home
+                                                    directory (HOME, else
+                                                    passwd pw_dir) before
+                                                    exec'ing the shell or
+                                                    alternate binary.  without
+                                                    this flag the child inherits
+                                                    the host process cwd.
+                                                */
+
 #define VTERM_FLAG_AIO          (1UL << 7)      //  async i/o
 #define VTERM_FLAG_NOPTY        (1UL << 8)      /*
                                                     skip all the fd and pty

--- a/vterm_exec.c
+++ b/vterm_exec.c
@@ -1,6 +1,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <pwd.h>
 
 #include "vterm.h"
@@ -33,11 +34,41 @@ vterm_set_exec(vterm_t *vterm, char *path, char **exec_argv)
     return;
 }
 
+/*
+    child-side only (post-forkpty).  when VTERM_FLAG_START_HOME is set,
+    move into the user's home before exec so the shell or alternate
+    binary does not inherit the host process cwd.
+*/
+static void
+_vterm_chdir_home(void)
+{
+    const char      *home;
+    struct passwd   *pw;
+
+    home = getenv("HOME");
+    if(home == NULL || home[0] == '\0')
+    {
+        pw = getpwuid(getuid());
+        if(pw != NULL) home = pw->pw_dir;
+    }
+
+    if(home != NULL && home[0] != '\0')
+    {
+        if(chdir(home) == -1)
+            return;
+    }
+
+    return;
+}
+
 int
 vterm_exec_binary(vterm_t *vterm)
 {
     struct passwd   *user_profile;
     char            *user_shell = NULL;
+
+    if(vterm->flags & VTERM_FLAG_START_HOME)
+        _vterm_chdir_home();
 
     if(vterm->exec_path == NULL)
     {


### PR DESCRIPTION
Add an init flag that chdirs the post-fork child into the user's home (HOME, else passwd pw_dir) before execing the shell or alternate binary. Wire vshell --start-home and document it in --help.