### PR TITLE
fix: paste/pty-write reliability (10.8)

### DIFF
--- a/API
+++ b/API
@@ -61,9 +61,14 @@ pipe from filling up.
    void vterm_write_pipe(vterm_t *vterm, uint32_t keycode);
 
 Writes a keycode to the terminal.  Special keys such as the F(x) keys are
-translated into the escape sequences expected by the shell.  If you wish
-to write raw data to the receiving process, do not use this function.  Use
-the file descriptor with write().
+translated into the escape sequences expected by the shell.
+
+   ssize_t vterm_write_data(vterm_t *vterm, const void *data, size_t len);
+
+Writes a raw byte buffer to the child pty (paste / bulk input).  Completes
+the full write (retries short writes, EINTR, EAGAIN).  When the child has
+enabled DECSET 2004, wraps the payload with ESC[200~ ... ESC[201~.  Prefer
+this over a per-byte vterm_write_pipe loop for paste.
 
    const char* vterm_get_ttyname(vterm_t *vterm);
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,22 @@
+10.8
+
+Paste / pty-write reliability
+* [Bryan Christ] Add vterm_write_data(vterm, data, len): bulk raw write to the
+  child pty with full write-all (short writes, EINTR, EAGAIN/POLLOUT retried).
+  Prefer this over a per-byte vterm_write_pipe loop for paste -- one transfer,
+  no silent character loss when the master buffer fills.
+* [Bryan Christ] When the child has enabled DECSET 2004 (bracketed paste),
+  vterm_write_data wraps the payload with ESC[200~ ... ESC[201~.  Per-keystroke
+  vterm_write_pipe is never wrapped.  SM/RM 2004 now track STATE_BRACKETED_PASTE
+  instead of no-op stubs.
+* [Bryan Christ] Multi-byte packed keycodes (ESC-then-payload from the host
+  kmio layer) are emitted low-byte-first, matching the pack order.  The old
+  high-to-low unpack inverted every Alt/escape sequence and mangled host
+  bracketed-paste wrappers on the way to the child.
+* [Bryan Christ] Pty master O_NONBLOCK is set with F_SETFL (was F_SETFD, which
+  never applied the flag).  Combined with write-all, keystroke and paste writes
+  complete without hanging the host or dropping bytes.
+
 10.7
 
 Scrollback-view cell copy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.10.2)
 
 project(libvterm C)
 set(MAJOR_VERSION 10)
-set(MINOR_VERSION 7)
+set(MINOR_VERSION 8)
 
 message("CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 

--- a/vterm.c
+++ b/vterm.c
@@ -202,8 +202,13 @@ vterm_init(vterm_t *vterm, uint16_t width, uint16_t height, uint32_t flags)
         }
     }
 
-    fd_flags = fcntl(vterm->pty_fd, F_GETFD);
-    fcntl(vterm->pty_fd, F_SETFD, fd_flags | O_NONBLOCK);
+    /* status flags (O_NONBLOCK), not FD flags (FD_CLOEXEC).  Was F_SETFD,
+       which silently no-op'd the nonblock request and left the master
+       blocking.  Nonblocking + write-all in _vterm_write_pty keeps paste
+       and keystroke writes from hanging the host while still completing. */
+    fd_flags = fcntl(vterm->pty_fd, F_GETFL);
+    if(fd_flags != -1)
+        fcntl(vterm->pty_fd, F_SETFL, fd_flags | O_NONBLOCK);
 
     use_extended_names(TRUE);
     vterm->write = vterm_write_keymap;

--- a/vterm.h
+++ b/vterm.h
@@ -424,6 +424,29 @@ ssize_t         vterm_read_pipe(vterm_t *vterm, int timeout);
 */
 int             vterm_write_pipe(vterm_t *vterm, uint32_t keycode);
 
+/*
+    write a raw byte buffer to the child's pty (paste, bulk input).
+
+    Completes the full write: short writes and EINTR/EAGAIN are retried
+    until every byte is delivered or a hard error occurs.  Prefer this
+    over a per-byte vterm_write_pipe loop for paste -- one buffer, one
+    logical transfer, no dropped characters on a full pty.
+
+    When the child has enabled bracketed paste (DECSET 2004), the payload
+    is wrapped with ESC[200~ ... ESC[201~ so the guest can treat it as a
+    single paste rather than typed keystrokes.  Per-keystroke
+    vterm_write_pipe is not wrapped (that would be wrong for real typing).
+
+    @params:
+        vterm           a valid vterm object handle.
+        data            bytes to write; may be NULL only when len == 0.
+        len             number of bytes in data.
+
+    @return:            len on success, -1 on error.  Bracket wrappers are
+                        not counted in the return value.
+*/
+ssize_t         vterm_write_data(vterm_t *vterm, const void *data, size_t len);
+
 int             vterm_write_mouse_event(vterm_t *vterm, MEVENT *mouse_event);
 
 /*

--- a/vterm_dec_RM.c
+++ b/vterm_dec_RM.c
@@ -146,10 +146,10 @@ interpret_dec_RM(vterm_t *vterm, int param[], int pcount)
             continue;
         }
 
-        // stub for turning off bracked paste
+        // DECRST 2004 -- bracketed paste off
         if(param[i] == 2004)
         {
-            // todo
+            vterm->internal_state &= ~STATE_BRACKETED_PASTE;
             continue;
         }
     }

--- a/vterm_dec_SM.c
+++ b/vterm_dec_SM.c
@@ -174,11 +174,10 @@ interpret_dec_SM(vterm_t *vterm, int param[], int pcount)
             continue;
         }
 
-        // stub for enabling bracketed paste
+        // DECSET 2004 -- bracketed paste (wrap bulk pastes in ESC[200~..201~)
         if(param[i] == 2004)
         {
-            // todo
-
+            vterm->internal_state |= STATE_BRACKETED_PASTE;
             continue;
         }
     }

--- a/vterm_private.h
+++ b/vterm_private.h
@@ -44,6 +44,7 @@
                                                     to the scroll region
                                                 */
 #define STATE_CURSOR_APP        (1UL << 16)     //  DECCKM: application cursor keys
+#define STATE_BRACKETED_PASTE   (1UL << 17)     //  DECSET 2004: wrap pastes
 
 #define IS_MODE_ESCAPED(x)      (x->internal_state & STATE_ESCAPE_MODE)
 #define IS_MODE_ACS(x)          (x->internal_state & STATE_ALT_CHARSET)

--- a/vterm_write.c
+++ b/vterm_write.c
@@ -4,6 +4,9 @@
 #include <termios.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
+#include <poll.h>
+#include <limits.h>
 
 #include "vterm.h"
 #include "vterm_private.h"
@@ -212,7 +215,7 @@ typedef union _key_alignment_u  key_alignment_t;
 
 
 int
-_vterm_write_pty(vterm_t *vterm, unsigned char *buf, ssize_t bytes);
+_vterm_write_pty(vterm_t *vterm, const unsigned char *buf, ssize_t bytes);
 
 int
 vterm_write_pipe(vterm_t *vterm, uint32_t keycode)
@@ -363,23 +366,30 @@ vterm_write_keymap(vterm_t *vterm, uint32_t keycode)
         return retval;
     }
 
-    // there's probably a more elegant way to do this but
+    /*
+        Multi-byte keycodes from the host kmio layer pack wire bytes in
+        chronological order into the low half of the word: first byte in
+        bits 0-7 (ESC for Alt combos), second in 8-15, third in 16-23.
+        Emit low-to-high so ESC-V leaves as ESC then V, not V then ESC.
+        The old high-to-low unpack inverted every packed sequence and
+        mangled host bracketed-paste wrappers (ESC[200~ / ESC[201~).
+    */
     if(keycode > 0xFFFF)
     {
-        buf[0] = (keycode & 0x00FF0000) >> 16;
-        buf[1] = (keycode & 0x0000FF00) >> 8;
-        buf[2] = (keycode & 0x000000FF);
+        buf[0] = (unsigned char)(keycode & 0x000000FF);
+        buf[1] = (unsigned char)((keycode & 0x0000FF00) >> 8);
+        buf[2] = (unsigned char)((keycode & 0x00FF0000) >> 16);
         bytes = 3;
     }
     else if(keycode > 0xFF)
     {
-        buf[0] = (keycode & 0x0000FF00) >> 8;
-        buf[1] = (keycode & 0x000000FF);
+        buf[0] = (unsigned char)(keycode & 0x000000FF);
+        buf[1] = (unsigned char)((keycode & 0x0000FF00) >> 8);
         bytes = 2;
     }
     else
     {
-        buf[0] = (keycode & 0x000000FF);
+        buf[0] = (unsigned char)(keycode & 0x000000FF);
         bytes = 1;
     }
 
@@ -388,21 +398,97 @@ vterm_write_keymap(vterm_t *vterm, uint32_t keycode)
     return retval;
 }
 
+/*
+    Deliver the full buffer to the pty master.  Retries short writes and
+    EINTR; on EAGAIN waits for POLLOUT (the master is nonblocking).  A
+    single write() used to drop the remainder on short write or EAGAIN --
+    silent character loss under paste load.
+*/
 int
-_vterm_write_pty(vterm_t *vterm, unsigned char *buf, ssize_t bytes)
+_vterm_write_pty(vterm_t *vterm, const unsigned char *buf, ssize_t bytes)
 {
-    ssize_t bytes_written = 0;
+    ssize_t             total = 0;
+    ssize_t             n;
+    struct pollfd       pfd;
 
-    if(buf == NULL) return -1;
+    if(buf == NULL || bytes < 0) return -1;
+    if(bytes == 0) return 0;
+    if(vterm == NULL || vterm->pty_fd < 0) return -1;
 
-    bytes_written = write(vterm->pty_fd, buf, bytes);
-    if(bytes_written != bytes)
+    while(total < bytes)
     {
+        n = write(vterm->pty_fd, buf + total, (size_t)(bytes - total));
+        if(n > 0)
+        {
+            total += n;
+            continue;
+        }
+
+        if(n < 0 && errno == EINTR)
+            continue;
+
+        if(n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+        {
+            memset(&pfd, 0, sizeof(pfd));
+            pfd.fd = vterm->pty_fd;
+            pfd.events = POLLOUT;
+            if(poll(&pfd, 1, -1) < 0)
+            {
+                if(errno == EINTR)
+                    continue;
+                vterm_error(vterm, VTERM_ECODE_PTY_WRITE_ERR, NULL);
+                return -1;
+            }
+            continue;
+        }
+
         vterm_error(vterm, VTERM_ECODE_PTY_WRITE_ERR, NULL);
         return -1;
     }
 
-    return bytes_written;
+    return (int)total;
+}
+
+ssize_t
+vterm_write_data(vterm_t *vterm, const void *data, size_t len)
+{
+    static const unsigned char bp_start[] = { 0x1b, '[', '2', '0', '0', '~' };
+    static const unsigned char bp_end[]   = { 0x1b, '[', '2', '0', '1', '~' };
+    const unsigned char        *buf;
+    int                         bracket;
+
+    if(vterm == NULL) return -1;
+    if(len == 0) return 0;
+    if(data == NULL) return -1;
+
+    /* size_t -> ssize_t: reject absurd lengths rather than truncate */
+    if(len > (size_t)SSIZE_MAX) return -1;
+
+    buf = (const unsigned char *)data;
+    bracket = (vterm->internal_state & STATE_BRACKETED_PASTE) ? 1 : 0;
+
+    if(bracket)
+    {
+        if(_vterm_write_pty(vterm, bp_start, (ssize_t)sizeof(bp_start)) < 0)
+            return -1;
+    }
+
+    if(_vterm_write_pty(vterm, buf, (ssize_t)len) < 0)
+        return -1;
+
+    if(bracket)
+    {
+        if(_vterm_write_pty(vterm, bp_end, (ssize_t)sizeof(bp_end)) < 0)
+            return -1;
+    }
+
+    if(vterm->event_mask & VTERM_MASK_PIPE_WRITTEN)
+    {
+        if(vterm->event_hook != NULL)
+            vterm->event_hook(vterm, VTERM_MASK_PIPE_WRITTEN, NULL);
+    }
+
+    return (ssize_t)len;
 }
 
 int


### PR DESCRIPTION
Add vterm_write_data for bulk paste with write-all retries, fix multi-byte keycode byte order, track DECSET 2004, and set O_NONBLOCK via F_SETFL so characters are not dropped mid-paste.